### PR TITLE
Yet another portion of reformatted posts

### DIFF
--- a/_posts/2005-09-22-static-calls-to-virtual-methods-and-verifiability.md
+++ b/_posts/2005-09-22-static-calls-to-virtual-methods-and-verifiability.md
@@ -17,43 +17,56 @@ author:
   first_name: ''
   last_name: ''
 ---
-We made a change in Whidbey recently that impacts the verification of **call**
+We made a change in Whidbey recently that impacts the verification of `call`
 s to virtual methods.
 
-**Invoking Virtual Methods Statically**
+### Invoking Virtual Methods Statically
 
 Valid IL could previously invoke a precise implementation of a virtual method
-with a **call** instruction instead of a **callvirt**. The target type's exact
+with a `call` instruction instead of a `callvirt`. The target type's exact
 method token could be specified, bypassing all dynamic dispatch altogether. For
-example, given two classes A and B
+example, given two classes `A` and `B`
 
-> class A { public virtual void f() { Console.WriteLine("A::f"); } }
->
->
->
-> class B : A { public override void f() { Console.WriteLine("B::f"); } }
+    class A
+    {
+      public virtual void f()
+      {
+        Console.WriteLine("A::f");
+      }
+    }
+
+    class B : A
+    {
+      public override void f()
+      {
+        Console.WriteLine("B::f");
+      }
+    }
 
 a consumer would ordinarily emit IL to perform a virtual dispatch, looking
 something like this in IL
 
-> newobj instance void B::.ctor() callvirt instance void A::f()
+    newobj instance void B::.ctor()
+    callvirt instance void A::f()
 
 The result is of course a properly dispatched virtual call which resolves to
-B's override and prints out "B::f". But somebody could do this instead
+`B`s override and prints out "B::f". But somebody could do this instead
 
-> newobj instance void B::.ctor() call instance void A::f()
+    newobj instance void B::.ctor()
+    call instance void A::f()
 
-The result of which is an ordinary statically dispatched call to A's
+The result of which is an ordinary statically dispatched call to `A`s
 implementation of f, printing out "A::f".
 
 Some consider this a violation of _privacy through inheritence_. Lots of code
 is written under the assumption that overriding a virtual method is sufficient
 to guarantee  custom logic within gets called. Intuitively, this makes sense,
 and C# lulls you into this sense of security because it always emits calls to
-virtual methods as **callvirt** s. C++ offers language syntax to do precisely
+virtual methods as `callvirt`s. C++ offers language syntax to do precisely
 this, however, e.g.
 
-> B b; b.A::f();
+    B b;
+    b.A::f();
 
 I don't know of any other language that support this type of call directly, but
 presumably somebody else followed in C++'s footsteps here. C# (and others) use
@@ -62,7 +75,7 @@ this type of IL so that their method resolution code can bind to virtual
 methods in a custom way. And others could do it in an attempt to "devirtualize"
 method calls when they know there are no overrides.
 
-**Verification Changes**
+### Verification Changes
 
 Late in Whidbey, some folks decided this is subtly strange enough that we at
 least don't want partially trusted code to be doing it. That it's even possible
@@ -71,42 +84,54 @@ and reality through the introduction of a new verification rule.
 
 The rule restricts the manner in which callers can make non-virtual calls to
 virtual methods, specifically by only permitting it if the target method is
-being called on the caller's 'this' pointer. This effectively allows an object
+being called on the caller's `this` pointer. This effectively allows an object
 to call up (or down, although that would be odd) its own type hierarchy. With
 this change, the above example fails verification, "The 'this' parameter to the
 call must be the calling method's 'this' parameter."
 
-**Identity Tracking**
+### Identity Tracking
 
 The verifier implements this magic using a technique called identity tracking.
 We don't use this style of tracking in many places. The verifier ordinarily
 tracks only the static type of items on the stack. But in this case, it needs
-to be comfortable that you're using the same _arg.0_ pointer for the method
-call as was passed onto the caller's stack frame. If you've executed a _starg
-0_ in the IL stream, for example, you won't be permitted to make the call. Even
-if you do a _ldarg.0_ followed by a _starg 0_, the verifier tosses you out the
+to be comfortable that you're using the same `arg.0` pointer for the method
+call as was passed onto the caller's stack frame. If you've executed a `starg.0`
+in the IL stream, for example, you won't be permitted to make the call. Even
+if you do a `ldarg.0` followed by a `starg 0`, the verifier tosses you out the
 window.
 
-A catch here is that while you might be operating dynamically on the 'this'
+A catch here is that while you might be operating dynamically on the `this`
 pointer, the verifier avoids statically tracking pointers across method calls.
 An example of where this can produce a false positive is as follows
 
-> class A { public virtual void f() { Console.WriteLine("Foo::f"); } }
->
->
->
-> class B : A { public override void f() { Console.WriteLine("Bar::f"); }
->
->
->
->     private B Echo(B b) { return b; }
->
->
->
->     public void FailsVerification() { Echo(this).A::f(); } }
+    class A
+    {
+      public virtual void f()
+      {
+        Console.WriteLine("Foo::f");
+      }
+    }
 
-It's clear that FailsVerification is really just invoking methods on its this
-pointer. But it does so in a roundabout fashion. (Of course that 'A::f()'
+    class B : A
+    {
+      public override void f()
+      {
+        Console.WriteLine("Bar::f");
+      }
+
+      private B Echo(B b)
+      {
+        return b;
+      }
+
+      public void FailsVerification()
+      {
+        Echo(this).A::f();
+      }
+    }
+
+It's clear that `FailsVerification` is really just invoking methods on its `this`
+pointer. But it does so in a roundabout fashion. (Of course that `A::f()`
 syntax is psuedo-code; it would compile in C++, but C# doesn't offer such a
 feature.) Regardless, the IL that gets produced isn't verifiable.
 

--- a/_posts/2005-09-29-rude-unloads-and-orphaned-locks.md
+++ b/_posts/2005-09-29-rude-unloads-and-orphaned-locks.md
@@ -20,29 +20,29 @@ author:
 I've talked about Thread Aborts
 [before](http://www.bluebytesoftware.com/blog/PermaLink.aspx?guid=c1898a31-a0aa-40af-871c-7847d98f1641).
 And I [spoke briefly at
-PDC](http://216.55.183.63/pdc2005/slides/FUN405_Duffy.ppt)about why you
+PDC](http://216.55.183.63/pdc2005/slides/FUN405_Duffy.ppt) about why you
 shouldn't lock on objects shared across AppDomains (ADs). But I wanted to spend
 a brief moment fusing the two together to illustrate the point. There are some
 interesting factors at play here.
 
-**The Guidance**
+### The Guidance
 
 To begin with, [our Design
 Guidelines](http://www.amazon.com/exec/obidos/ASIN/0321246756/bluebytesoftw-20)
 advise:
 
 > **Do not** lock on any public types, or on instances you do not control.
-> Notice that the common constructs lock (this), lock (typeof (Type)), and lock
-> ("myLock") violate this guideline.
+> Notice that the common constructs `lock (this)`, `lock (typeof (Type))`, and 
+> `lock ("myLock")` violate this guideline.
 
-Most people don't intuitively understand the why behind not locking on Types
-and Strings. I'll leave the public type discussion off the table for this post.
+Most people don't intuitively understand the why behind not locking on `Type`s
+and `String`s. I'll leave the public type discussion off the table for this post.
 
-**The Reasons**
+### The Reasons
 
 To understand why this is problematic, first you have to understand that we
 share objects across ADs. And you need to understand when we do it. Various
-Reflection bits and bytes—such as instances of the Type class—are one such
+Reflection bits and bytes—such as instances of the `Type` class—are one such
 case, when they refer to a domain neutral assembly. mscorlib always gets loaded
 domain neutral, for example; other assemblies can fall into this category too,
 based on Hosting policies. Interned strings are also shared across ADs, so a
@@ -66,25 +66,25 @@ picture of the world. During ordinary AD unloads we are careful to ensure that
 threads are unwound in an orderly fashion. That is to say, finally blocks
 lexically surrounding the instruction pointer are run, and of course objects in
 that AD are given a chance to run their Finalizers. This happens because a
-ThreadAbortException is generated at the current point of execution in each
+`ThreadAbortException` is generated at the current point of execution in each
 thread which actively has a stack in the AD.
 
-Assuming you've written your code to use a lock statement (or at least to
-release the Monitor in a finally block), this orderly thread unwinding permits
+Assuming you've written your code to use a `lock` statement (or at least to
+release the `Monitor` in a finally block), this orderly thread unwinding permits
 you to release any locks held. You may catch a Thread Abort, but it is a
 so-called undeniable exception, meaning it will be reraised at the end of your
 catch blocks. This is quite visible during an ordinary unload. And of course,
 Aborts are suspended in the case that you're in a CER, unmanaged chunk of code
 that isn't polling for aborts, a finally block, and so on. Lastly, if you see
-an Abort happen when your code holds a Monitor, you can be assured the entire
-AD is being ripped—not just a single Thread; this assumption is safe because
+an `Abort` happen when your code holds a `Monitor`, you can be assured the entire
+AD is being ripped—not just a single `Thread`; this assumption is safe because
 we work with Hosts (via Begin- and EndCriticalRegion) to let them know when the
 whole AD could become corrupt as the result of a single ThreadAbort.
 
 But if you piss SQL Server off by taking too long in one of your finally blocks
 (for example), it will get a tad snippy. Specifically, it can respond by
 escalating to a rude AD unload. A rude unload does not tear the AD down by
-injecting ThreadAbortExceptions and enabling them to percolate back to the top
+injecting `ThreadAbortException`s and enabling them to percolate back to the top
 of the call-stack. Rather, it rips it down very aggressively, bypassing
 lexically relevant finally blocks, only giving a best effort attempt at running
 CERs, and executing critical finalizers (CFOs) only. Of course, this isn't
@@ -92,11 +92,11 @@ nearly as aggressive as a P/Invoke to kernel32!TerminateProcess, but it's not
 quite as polite as an ordinary unload.
 
 This means, as a very specific example, that a finally block wishing to execute
-Monitor.Exit won't even get run. And if the Exit doesn't run, that Monitor will
+`Monitor.Exit` won't even get run. And if the `Exit` doesn't run, that `Monitor` will
 be permanently left stamped with the Thread's ID as the owner. But the Thread
 has gone bye-bye. Orphaned. Until you've created 4,294,967,295 threads such
 that the Thread IDs wrap around and the old ID gets assigned to a new Thread,
-and that thread spuriously decides to Exit the Monitor without acquiring it
+and that thread spuriously decides to `Exit` the `Monitor` without acquiring it
 first, your system is going to be locked up for a bit. In other words,
 deadlocked.
 
@@ -117,34 +117,69 @@ general idea is described in more detail in Stephen Toub's recent [excellent
 MSDN
 article](http://msdn.microsoft.com/msdnmag/issues/05/10/Reliability/default.aspx),
 and in gory detail in the [Customizing the
-CLR](http://www.amazon.com/exec/obidos/ASIN/0735619883/bluebytesoftw-20)book.
+CLR](http://www.amazon.com/exec/obidos/ASIN/0735619883/bluebytesoftw-20) book.
 
-**A Demonstration**
+### A Demonstration
 
 Let's first take a look at and observe the effects of a scenario which locks on
 cross-AD objects:
 
-> using System; using System.Threading;
->
-> class Program { static void Main() { // Start up a new AppDomain that hogs a
-> lock.  AppDomain ad = AppDomain.CreateDomain("FooDomain");
-> ad.DoCallBack(delegate { Thread t = new Thread(delegate() {
-> lock(typeof(string)) { try { Console.WriteLine("AD#B: Got it.");
-> Thread.Sleep(10000); } catch (Exception e) { Console.WriteLine("AD#B: {0}",
-> e); //Thread.Sleep(5000); // provoke a rude unload?  } } }); t.Start(); });
->
->         // Pause briefly.  Thread.Sleep(500);
->
->         // This will fail because AD#B owns the shared lock.  bool b =
->         Monitor.TryEnter(typeof(string), 500); if (b) {
->         Console.WriteLine("AD#A: Got it."); Monitor.Exit(typeof(string)); }
->
->         // Kill the other AppDomain.  AppDomain.Unload(ad);
->         Console.WriteLine("AD#A: AD#B is dead.");
->
->         // Is the lock orphaned? If we provoked a rude unload, this should
->         hang.  lock(typeof(string)) { Console.WriteLine("AD#A: I got in!"); }
->         } }
+    using System;
+    using System.Threading;
+
+    class Program
+    {
+      static void Main()
+      {
+        // Start up a new AppDomain that hogs a lock.
+        AppDomain ad = AppDomain.CreateDomain("FooDomain");
+
+        ad.DoCallBack(delegate
+        {
+          Thread t = new Thread(delegate()
+          {
+            lock(typeof(string))
+            {
+              try
+              {
+                Console.WriteLine("AD#B: Got it.");
+                Thread.Sleep(10000);
+              }
+              catch (Exception e)
+              {
+                Console.WriteLine("AD#B: {0}", e);
+                //Thread.Sleep(5000); // provoke a rude unload?
+              }
+            }
+          });
+          
+          t.Start();
+        });
+
+        // Pause briefly.
+        Thread.Sleep(500);
+
+        // This will fail because AD#B owns the shared lock.
+        bool b = Monitor.TryEnter(typeof(string), 500);
+        
+        if (b)
+        {
+          Console.WriteLine("AD#A: Got it.");
+          Monitor.Exit(typeof(string));
+        }
+
+        // Kill the other AppDomain.
+        AppDomain.Unload(ad);
+
+        Console.WriteLine("AD#A: AD#B is dead.");
+
+        // Is the lock orphaned? If we provoked a rude unload, this should hang.
+        lock(typeof(string))
+        {
+          Console.WriteLine("AD#A: I got in!");
+        }
+      }
+    }
 
 I hope the code is simple enough to be obvious. A brief explanation is
 warranted:
@@ -154,7 +189,7 @@ warranted:
 
 2. T1 resumes and waits briefly to ensure T2 can make forward progress first;
 
-3. T2 locks on typeof(String), and then goes to sleep for a while;
+3. T2 locks on `typeof(String)`, and then goes to sleep for a while;
 
 4. Meanwhile, T1 resumes, attempts to acquire the lock, and fails (because the
    lock is held by T2 because the String type is shared across ADs);
@@ -169,11 +204,17 @@ warranted:
 Throughout all of this, there is some nice text being printed to the console. I
 see the following:
 
-> AD#B: Got it.  AD#B: System.Threading.ThreadAbortException: Thread was being
+> AD#B: Got it.
+>
+> AD#B: System.Threading.ThreadAbortException: Thread was being
 > aborted.  at System.Threading.Thread.SleepInternal(Int32 millisecondsTimeout)
-> at Program.<Main>b\_\_1() AD#A: AD#B is dead.  AD#A: I got in!
+> at Program.<Main>b\_\_1()
+>
+> AD#A: AD#B is dead.
+>
+> AD#A: I got in!
 
-**Looks Fine, Eh?**
+### Looks Fine, Eh?
 
 Well that works just fine in unhosted scenarios, as we might have expected it
 to. The lock-protected bits of code stomp on each other, but at least AD #B
@@ -192,7 +233,7 @@ executed. Presumably SQL Server would notice this deadlock and kill the
 code—perhaps leading to both ADs ultimately being unloaded—but I am not
 100% certain about this.
 
-**A Possible Refinement**
+### A Possible Refinement
 
 Through a combination of CERs, we can get our code working again. Note
 that—if it's not obvious by now—the real solution is to avoid locking on
@@ -201,66 +242,80 @@ But of course, the geek inside instigates more fun…
 
 [Brian Grunkemeyer](http://blogs.msdn.com/bclteam/), a developer on our team,
 wrote a great piece of code sometime between Beta2 of Whidbey and now. It's a
-method on Monitor called ReliableEnter, and it permits you to acquire a Monitor
-and know reliably whether it succeeded. It does so with a Boolean byref
+method on `Monitor` called `ReliableEnter`, and it permits you to acquire a `Monitor`
+and know reliably whether it succeeded. It does so with a `Boolean` byref
 parameter which is set inside of a ThreadAbort-safe region of native code. This
-means that you can actually rely on the value of the Boolean in a cleanup CER,
-for example, to indicate whether the Monitor was successfully acquired or not,
+means that you can actually rely on the value of the `Boolean` in a cleanup CER,
+for example, to indicate whether the `Monitor` was successfully acquired or not,
 while at the same time not actually suspending ThreadAborts by wrapping the
 whole acquisition in a CER.
 
 Unfortunately, we were unable to make it accessible in Whidbey. It's an
 internal method, and it got added too late. We'll probably do that in the
 future. To make calling it cheap and possible, I wrote a little hack that uses
-a DynamicMethod to bind to it. In fact I did a little more than just that. I'm
+a `DynamicMethod` to bind to it. In fact I did a little more than just that. I'm
 not going to analyze it in detail. Feel free to ask questions if you wonder how
 it works:
 
-> delegate void MonitorAction(); class ReliableMonitor { class Holder<T> {
-> internal Holder() { this.value = default(T); } internal Holder(T value) {
-> this.value = value; } internal T value; }
->
->
->
->     delegate void ReliableEnterDelegate(object obj, Holder<bool> taken);
->     private static ReliableEnterDelegate monReliableEnter;
->
->
->
->     static ReliableMonitor() { MethodInfo reMi =
->     typeof(Monitor).GetMethod("ReliableEnter", BindingFlags.Static |
->     BindingFlags.NonPublic); DynamicMethod dm = new
->     DynamicMethod("Mon\_ReliableEnter", null, new Type[] { typeof(object),
->     typeof(Holder<bool>) }, typeof(Program), true); ILGenerator ilg =
->     dm.GetILGenerator(); ilg.Emit(OpCodes.Ldarg\_0);
->     ilg.Emit(OpCodes.Ldarg\_1); ilg.Emit(OpCodes.Ldflda,
->     typeof(Holder<bool>).GetField("value", BindingFlags.Instance |
->     BindingFlags.NonPublic)); ilg.Emit(OpCodes.Call, reMi);
->     ilg.Emit(OpCodes.Ret); monReliableEnter =
->     (ReliableEnterDelegate)dm.CreateDelegate(typeof(ReliableEnterDelegate));
->     }
->
->
->
->     internal static void Enter(object obj) { Monitor.Enter(obj); }
->
->
->
->     internal static void RunWithLock(object obj, MonitorAction action) {
->     Holder<bool> taken = new Holder<bool>();
->
->
->
->         System.Runtime.CompilerServices.RuntimeHelpers.ExecuteCodeWithGuaranteedCleanup(
->         delegate { monReliableEnter(obj, taken); action(); }, delegate { if
->         (taken.value) { Monitor.Exit(obj); taken.value = false; } }, null); }
->
->
->
->     internal static void Exit(object obj) { Monitor.Exit(obj); } }
+    delegate void MonitorAction();
+    
+    class ReliableMonitor
+    {
+      class Holder<T>
+      {
+        internal Holder() { this.value = default(T); }
+        internal Holder(T value) { this.value = value; }
+        
+        internal T value;
+      }
 
-Notice the RunWithLock method. It uses a great method
-RuntimeHelpers.ExecuteCodeWithGuaranteedCleanup located in the
+      delegate void ReliableEnterDelegate(object obj, Holder<bool> taken);
+      private static ReliableEnterDelegate monReliableEnter;
+
+      static ReliableMonitor()
+      {
+        MethodInfo reMi = typeof(Monitor).GetMethod("ReliableEnter",
+                                                    BindingFlags.Static | BindingFlags.NonPublic);
+        DynamicMethod dm = new DynamicMethod(
+          "Mon_ReliableEnter", null, new Type[] { typeof(object), typeof(Holder<bool>) },
+          typeof(Program), true);
+        
+        ILGenerator ilg = dm.GetILGenerator();
+        ilg.Emit(OpCodes.Ldarg_0);
+        ilg.Emit(OpCodes.Ldarg_1);
+        ilg.Emit(OpCodes.Ldflda, typeof(Holder<bool>).GetField("value",
+                                                               BindingFlags.Instance | BindingFlags.NonPublic));
+        ilg.Emit(OpCodes.Call, reMi);
+        ilg.Emit(OpCodes.Ret);
+        
+        monReliableEnter = (ReliableEnterDelegate)dm.CreateDelegate(typeof(ReliableEnterDelegate));
+      }
+
+      internal static void Enter(object obj) { Monitor.Enter(obj); }
+
+      internal static void RunWithLock(object obj, MonitorAction action)
+      {
+        Holder<bool> taken = new Holder<bool>();
+        System.Runtime.CompilerServices.RuntimeHelpers.ExecuteCodeWithGuaranteedCleanup(
+          delegate
+          {
+            monReliableEnter(obj, taken);
+            action();
+          },
+          delegate
+          {
+            if (taken.value)
+            {
+              Monitor.Exit(obj);
+              taken.value = false;
+            }
+          }, null);
+      }
+
+      internal static void Exit(object obj) { Monitor.Exit(obj); } }
+
+Notice the `RunWithLock` method. It uses a great method
+`RuntimeHelpers.ExecuteCodeWithGuaranteedCleanup` located in the
 System.Runtime.CompilerServices namespace. We call it SRCSRHECWGC—pronounced
 "shreek shreck woogy-cuck"—for short around here. Well, we don't really call
 it that, but I think I will from now on. SRCSRHECWGC runs the first delegate
@@ -272,33 +327,61 @@ plug on your computer, for example.
 If we were to rewrite our code above to use the RunWithLock method, it could
 survive a rude AD unload and skirt the frightening onset of a deadlock:
 
-> class Program {
->
->
->
->     static void Main() { // Start up a new AppDomain that hogs a lock.
->     AppDomain ad = AppDomain.CreateDomain("FooDomain");
->     ad.DoCallBack(delegate { Thread t = new Thread(delegate() {
->     ReliableMonitor.RunWithLock(typeof(string), delegate { try {
->     Console.WriteLine("AD#B: Got it."); Thread.Sleep(10000); } catch
->     (Exception e) { Console.WriteLine("AD#B: {0}", e); //Thread.Sleep(5000);
->     // provoke a rude unload } }); }); t.Start(); });
->
->         // Pause briefly.  Thread.Sleep(500);
->
->         // This will fail because AD#B owns the shared lock.  bool b =
->         Monitor.TryEnter(typeof(string), 500); if (b) {
->         Console.WriteLine("AD#A: Got it."); Monitor.Exit(typeof(string)); }
->
->         // Kill the other AppDomain.  AppDomain.Unload(ad);
->         Console.WriteLine("AD#A: AD#B is dead.");
->
->         // Is the lock orphaned? If we provoked a rude unload, this should
->         hang.  lock(typeof(string)) { Console.WriteLine("AD#A: I got in!"); }
->         } }
+    class Program
+    {
+      static void Main()
+      {
+        // Start up a new AppDomain that hogs a lock.
+        AppDomain ad = AppDomain.CreateDomain("FooDomain");
+
+        ad.DoCallBack(delegate
+        {
+          Thread t = new Thread(delegate()
+          {
+            ReliableMonitor.RunWithLock(typeof(string), delegate
+            {
+              try
+              {
+                Console.WriteLine("AD#B: Got it.");
+                Thread.Sleep(10000);
+              }
+              catch (Exception e)
+              {
+                Console.WriteLine("AD#B: {0}", e);
+                //Thread.Sleep(5000);  // provoke a rude unload
+              }
+            });
+          });
+          
+          t.Start();
+        });
+
+        // Pause briefly.
+        Thread.Sleep(500);
+
+        // This will fail because AD#B owns the shared lock.
+        bool b = Monitor.TryEnter(typeof(string), 500);
+        
+        if (b)
+        {
+          Console.WriteLine("AD#A: Got it.");
+          Monitor.Exit(typeof(string));
+        }
+
+        // Kill the other AppDomain.
+        AppDomain.Unload(ad);
+        Console.WriteLine("AD#A: AD#B is dead.");
+
+        // Is the lock orphaned? If we provoked a rude unload, this should hang.
+        lock(typeof(string))
+        {
+          Console.WriteLine("AD#A: I got in!");
+        }
+      }
+    }
 
 This has the effect that we wanted. When run in a situation where the
-RunWithLock method guarantees that we release the lock even in the face of a
+`RunWithLock` method guarantees that we release the lock even in the face of a
 rude unload. The result? AD #A does not deadlock.
 
 Hoorah.

--- a/_posts/2005-10-05-boxing-nullable-and-verification.md
+++ b/_posts/2005-10-05-boxing-nullable-and-verification.md
@@ -19,7 +19,7 @@ author:
 ---
 Our verifier has knowledge of statically typed boxed value types. Such things
 are never surfaced to user code, not even through reflection. In user code, the
-type of a statically typed boxed value can only be referred to as _object_,
+type of a statically typed boxed value can only be referred to as `object`,
 both statically and dynamically. This is one of the nice properties of a
 nominal type system; if you can't name it, you can't refer to it.
 
@@ -27,56 +27,56 @@ We use boxed types for type tracking in the verifier. This is why it's legal to
 make virtual method calls against boxed value types, for example, and similar
 reasons apply to the formation of delegates over boxed value types. Using the
 box instruction's type token argument, we can easily calculate the resulting
-boxed type. We say the result of boxing a value of type _T _is an item on the
-stack of type boxed<_T_>.
+boxed type. We say the result of boxing a value of type `T` is an item on the
+stack of type `boxed<T>`.
 
 Well, most of the time...
 
-**nullbox Rears its Head**
+### nullbox Rears its Head
 
 Life was simple before [the nullbox
 DCR](http://www.bluebytesoftware.com/blog/PermaLink.aspx?guid=104175ad-2448-4607-bd12-4b02f877fe29).
-In the good ole' days, when you boxed a value of type _T_, you got back a
-boxed<_T_>. Always. But now things change ever-so-slightly. If _T_ is a
-Nullable<_U_>, the static type of the item left on the stack is a boxed<_U_>;
-all other cases are still typed as boxed<_T_>. Given that you can only refer to
-these things as 'object', perhaps this isn't concerning to you.
+In the good ole' days, when you boxed a value of type `T`, you got back a
+`boxed<T>`. Always. But now things change ever-so-slightly. If `T` is a
+`Nullable<U>`, the static type of the item left on the stack is a `boxed<U>`;
+all other cases are still typed as `boxed<T>`. Given that you can only refer to
+these things as `object`, perhaps this isn't concerning to you.
 
 But from the verifier's perspective, it changes the user-observable semantics.
-It means you can't verifiably form a delegate over a Nullable<_U_> _ever_. The
-only way to produce something of type boxed<_T_> is through the use of a 'box'
-instruction; and we've established box<Nullable<_U_>> is a boxed<_U_>. There
-should be no way to produce a boxed<Nullable<_U_>>. It similarly means that you
-can't call virtual methods on a Nullable<_U_> because, by definition, you must
+It means you can't verifiably form a delegate over a `Nullable<U>` _ever_. The
+only way to produce something of type `boxed<T>` is through the use of a `box`
+instruction; and we've established `box<Nullable<U>>` is a `boxed<U>`. There
+should be no way to produce a `boxed<Nullable<U>>`. It similarly means that you
+can't call virtual methods on a `Nullable<U>` because, by definition, you must
 box value types in order to callvirt them.
 
 (This statement doesn't apply to all virtual method dispatch. If you use
 constrained calls--as the C# compiler does--they do the magic to determine if
 there's a suitable implementation on the target type and, if so, avoids boxing.
 They operate on the raw unboxed item as 'this'. This applies when you call
-ToString on a Nullable, for example, because Nullable overrides it.)
+`ToString` on a `Nullable`, for example, because `Nullable` overrides it.)
 
 Notice also that this is the very magic that permits you to make interface
-calls on a Nullable<T> for interfaces that T supports. It gets boxed and the
+calls on a `Nullable<T>` for interfaces that `T` supports. It gets boxed and the
 type tracking permits you to perform the operation.
 
-**Type Hole?**
+### Type Hole?
 
 A type hole is a situation where the dynamic type of something doesn't match
 what the static verifier said it would be. This is very bad. By definition,
 something which is verifiably type safe should not be able to corrupt data at
 runtime as a result of such type mismatches. A sound type system has no holes.
-The change associated with nullbox, however, introduces one specific cause for
+The change associated with `nullbox`, however, introduces one specific cause for
 concern. We call it a "wart" but won't go so far as to call it a "type hole."
 
 Consider what happens if a box instruction were to operate using a type token
 which was parameterized by some generic parameter in the scope. In other words,
-the thing being boxed was of some type _T_ (perhaps declared on the enclosing
+the thing being boxed was of some type `T` (perhaps declared on the enclosing
 method) that wasn't known at verification time. Our verification rules state
-that the result of box '_T_' is always boxed<_T_>. But as we've seen already,
-if this scope were instantiated with Nullable<_U_> as the argument for the type
-parameter _T_, this would be a lie. The dynamic type is actually a boxed<_U_>,
-yet we said it was a boxed<Nullable<_U_>> (indirectly).
+that the result of box `T` is always `boxed<T>`. But as we've seen already,
+if this scope were instantiated with `Nullable<U>` as the argument for the type
+parameter `T`, this would be a lie. The dynamic type is actually a `boxed<U>`,
+yet we said it was a `boxed<Nullable<U>>` (indirectly).
 
 Unfortunately, because the verifier operates on abstract type forms, not
 precise generic instantiations, fixing this isn't quite as simple as you might
@@ -86,33 +86,33 @@ have the information it needs at verification time to determine whether it is
 lying.
 
 Why isn't this a type hole? If there was a property of an item statically typed
-as boxed<Nullable<_U_>> that you could verifiably make use of, but that wasn't
-also a property of boxed<_U_>, this would precisely the definition of a type
+as `boxed<Nullable<U>>` that you could verifiably make use of, but that wasn't
+also a property of `boxed<U>`, this would precisely the definition of a type
 hole stated aboved. We'd discover the problem at runtime. Right?
 
-**\*Whew!\***
+### \*Whew!\*
 
 It turns out you can't do any such things.
 
-First of all, you cannot do anything to an unconstrained type parameter _T_
-except perform operations statically verifiable against 'object'. A boxed<_U_>
-(the dynamic type of a static boxed<Nullable<_U_>>) is obviously a derivative
-of 'object', so this is OK. You couldn't verifiably form a delegate over a
-boxed<Nullable<_U_>>, for example, because of the _verifier _not the absence of
+First of all, you cannot do anything to an unconstrained type parameter `T`
+except perform operations statically verifiable against `object`. A `boxed<U>`
+(the dynamic type of a static `boxed<Nullable<U>>`) is obviously a derivative
+of `object`, so this is OK. You couldn't verifiably form a delegate over a
+`boxed<Nullable<_U_>>`, for example, because of the _verifier_ not the absence of
 Nullable's methods at runtime.
 
 Next, you can also constrain type parameters to things that implement specific
-interfaces. So if Nullable<_U_> implemented an interface that its inner _U_
+interfaces. So if `Nullable<U>` implemented an interface that its inner `U`
 didn't support, you could legally make interface calls which would cause holes
-at runtime. But (thankfully) Nullable<_U_> doesn't implement any interfaces.
-(Notice we removed INullableValue from Whidbey altogether. :P)
+at runtime. But (thankfully) `Nullable<U>` doesn't implement any interfaces.
+(Notice we removed `INullableValue` from Whidbey altogether. :P)
 
-Furthermore, Nullable<_U_>'s type parameter is constrained to value types, so
+Furthermore, `Nullable<U>`'s type parameter is constrained to value types, so
 even if you could represent a constraint that allowed only value type values
-for _T_ (which you can't, you can only use the 'valuetype' constraint which
-omits Nullable directly) you couldn't do anything dangerous.
+for `T` (which you can't, you can only use the 'valuetype' constraint which
+omits `Nullable` directly) you couldn't do anything dangerous.
 
-**Summary?**
+### Summary?
 
 Move along. Nothing to see here. I just typed up a brief summary because we
 were discussing this at great lengths during ECMA specification. It sparked a

--- a/_posts/2005-11-27-physical-os-threads-and-context.md
+++ b/_posts/2005-11-27-physical-os-threads-and-context.md
@@ -22,14 +22,14 @@ of user-mode memory pointed at and reserved for use by the Windows kernel
 Thread data structure (KTHREAD). In addition to basic OS information like the
 active SEH filter chain, stack base and limit, and owned critical sections,
 applications can easily stash data into and retrieve data out of the Thread
-Local Storage (TLS) area of the TEB. This is done using the Win32 TlsAlloc,
-TlsGetValue, TlsSetValue, and TlsFree functions. You can view the TEB via the
+Local Storage (TLS) area of the TEB. This is done using the Win32 `TlsAlloc`,
+`TlsGetValue`, `TlsSetValue`, and `TlsFree` functions. You can view the TEB via the
 kernel debugger's !thread command.
 
-(The CLR of course offers TLS functionality too, i.e. using ThreadStatics and
-the System.Threading.Thread's AllocateDataSlot, SetData, and GetData functions.
+(The CLR of course offers TLS functionality too, i.e. using `ThreadStatics` and
+the `System.Threading.Thread`'s `AllocateDataSlot`, `SetData`, and `GetData` functions.
 This information does go into the TEB, but it is managed by the CLR. A call to
-SetData does not translate directly to a call to TlsSetValue.)
+`SetData` does not translate directly to a call to `TlsSetValue`.)
 
 Win32--and Windows in general--makes liberal use of thread-local memory. I
 noted a few uses above (e.g. exception handlers) which are pervasive. Such
@@ -43,10 +43,10 @@ physical thread to another.
 
 Imagine what would happen if we made a call to some Win32 function and then
 decided to swap out the logical work so that we could install new work.
-SetLastError might have been used to communicate a failure in a function called
+`SetLastError` might have been used to communicate a failure in a function called
 on either the thread the work is being swapped out of, or the destination once
-it gets rescheduled. But SetLastError installs the error information into the
-TEB. GetLastError will then either fail to retrieve information or, more
+it gets rescheduled. But `SetLastError` installs the error information into the
+TEB. `GetLastError` will then either fail to retrieve information or, more
 likely, will retrieve somebody else's information, either of which would lead
 to all sorts of serious problems. Similar issues can happen if we (foolishly)
 tried to swap out a thread that owned a critical section, or some other
@@ -56,11 +56,11 @@ This is one major reason why fibers are still problematic as a general task
 scheduling solution for Windows. And it's a challenge if you even want to
 consider user-mode scheduling a la continuations. You just can't get around the
 platform's hidden thread affinity. We've done much better in managed code. Over
-time we are trying to use ExecutionContext as the currency for logical context
+time we are trying to use `ExecutionContext` as the currency for logical context
 information, which can be easily captured and restored by the runtime. But
 there are examples where we violate this (e.g. monitors), where we use the
 physical OS thread as the context (be fair: we do notify hosts of such
-situations via Thread.Begin/EndThreadAffinity).
+situations via `Thread.Begin/EndThreadAffinity`).
 
 But you can't escape the fact that the runtime itself is built right on top of
 Win32.

--- a/_posts/2005-12-27-never-write-a-finalizer-again-well-almost-never.md
+++ b/_posts/2005-12-27-never-write-a-finalizer-again-well-almost-never.md
@@ -40,9 +40,9 @@ complete, perhaps by [deadlocking on entry to a non-pumping
 STA](http://blogs.msdn.com/cbrumme/archive/2004/02/02/66219.aspx), causing the
 host to escalate to a rude unload.
 
-**Critical finalizers**
+### Critical finalizers
 
-During a rude unload, normal finalizers are skipped, finally blocks aren't run,
+During a rude unload, normal finalizers are skipped, `finally` blocks aren't run,
 and only critical finalizers get a chance to make the world sane again. Thus we
 can immediately form a guiding principle:
 
@@ -66,97 +66,97 @@ address space. If an AppDomain gets interrupted by an unload mid-way through a
 operation](http://www.bluebytesoftware.com/blog/PermaLink.aspx?guid=c1898a31-a0aa-40af-871c-7847d98f1641)
 and intends to clean up state in its finalizer, failure to execute the
 finalizer might lead to chaos. A critical finalizer should have been used. (And
-use of BeginDelayAbort, e.g. via a CER. But that's digging a little too deep
+use of `BeginDelayAbort`, e.g. via a CER. But that's digging a little too deep
 for now.)
 
 Critical finalizers are somewhat easier to write when compared to ordinary
 finalizers, due to the out-of-the-box plumbing that you get. But they impose
 _additional_ constraints on what you can actually do at finalization time. To
 implement a critical finalizer, simply subclass the
-System.Runtime.ConstrainedExecution.CriticalFinalizerObject (CFO) type, provide
+`System.Runtime.ConstrainedExecution.CriticalFinalizerObject` (CFO) type, provide
 a way for users to acquire a resource (e.g. in the constructor), and override
-its Finalize method to perform cleanup. When instantiated, your object will be
+its `Finalize` method to perform cleanup. When instantiated, your object will be
 placed onto the critical-finalization object queue. CFOs can be suppressed as
-usual with the GC.SuppressFinalize method, and can be re-registered onto the
-critical-finalization queue with the GC.ReRegisterForFinalize method. The CLR
+usual with the `GC.SuppressFinalize` method, and can be re-registered onto the
+critical-finalization queue with the `GC.ReRegisterForFinalize` method. The CLR
 then ensures your object is finalized should a rude unload occur; obviously, it
 also runs them in the same cases ordinary finalizers are run too: i.e. standard
 GC finalization, managed shut-down, ordinary AppDomain unload, etc. There is a
 weak guarantee that CFOs are finalized after other finalizable objects,
-specifically to accomodate relationships like how the FileStream must flush its
-buffer before its underlying SafeHandle has been released.
+specifically to accomodate relationships like how the `FileStream` must flush its
+buffer before its underlying `SafeHandle` has been released.
 
-As noted, writing a CFO Finalize method is trickier than a standard finalizer
+As noted, writing a CFO `Finalize` method is trickier than a standard finalizer
 due to additional constraints. This is because it can be called from inside of
 a CER if the host escalates to a rude unload. It must guarantee that state will
 not be corrupted as a result of its execution and that it will never fail (i.e.
 by leaking an exception). And of course you can only call non-virtual methods
 that make similar guarantees. This means your code has to be written to succeed
 in the most hostile of situations, for instance in situations where any attempt
-to allocate memory dynamically will be rejected via an OutOfMemoryException. If
+to allocate memory dynamically will be rejected via an `OutOfMemoryException`. If
 you let that exception leak, you've violated the contract and can expect the
 host to respond in any number of ways, including crashing the process
 immediately. CERs perform eager preparation to statically ensure your code can
 execute, jitting the transitive closure of methods you invoke, but it's easy to
 make a misstep here due to the massive number of hidden allocations in the
 runtime. A box instruction allocates memory; unbox does, too, but only if
-you're unboxing a Nullable<T>; throw has to manufacture a
-RuntimeWrappedException if you're throwing a non-Exception object; and so
+you're unboxing a `Nullable<T>`; throw has to manufacture a
+`RuntimeWrappedException` if you're throwing a non-Exception object; and so
 forth. And unfortunately there aren't any tools to prove that you've written
 your CER correctly. Thankfully most developers write bug free code on their
 first attempt. ;)
 
-**Critical- and safe-handles**
+### Critical- and safe-handles
 
 Using the base CFO type directly has a couple drawbacks. First, it doesn't
-fully implement the IDisposable pattern. There are two convenient Framework CFO
+fully implement the `IDisposable` pattern. There are two convenient Framework CFO
 abstract classes that do, both in the System.Runtime.InteropServices namespace:
-CriticalHandle and SafeHandle.
+`CriticalHandle` and `SafeHandle`.
 
-The CriticalHandle type is sufficient to get critical finalization semantics:
-you simply override its protected constructor and ReleaseHandle methods,
+The `CriticalHandle` type is sufficient to get critical finalization semantics:
+you simply override its protected constructor and `ReleaseHandle` methods,
 performing open and close operations inside of them respectively. Your
-ReleaseHandle implementation can be called from inside of a critical
+`ReleaseHandle` implementation can be called from inside of a critical
 finalization CER, so as with writing CFOs by hand you must make the same
 guarantees outlined above. This type provides a cleanly factored and
 encapsulated interface to your users.
 
-But more concerning is the fact that both CFO and CriticalHandle are still
+But more concerning is the fact that both CFO and `CriticalHandle` are still
 prone to security problems that you might need to worry about if you're
 building any sort of reusable Framework. BrianGru [outlines this situation
 here](http://blogs.msdn.com/bclteam/archive/2005/03/16/396900.aspx). To tackle
-those issues, you need SafeHandle. Implementing SafeHandle is much like
-CriticalHandle, in that you override the protected constructor and
-ReleaseHandle methods, and abide by CER rules inside of ReleaseHandle. One
+those issues, you need `SafeHandle`. Implementing `SafeHandle` is much like
+`CriticalHandle`, in that you override the protected constructor and
+`ReleaseHandle` methods, and abide by CER rules inside of `ReleaseHandle`. One
 additional piece is necessary, however: you must implement the abstract
-IsInvalid property getter and return true or false to indicate whether the
-SafeHandle refers to an invalid handle. (The SafeHandleMinusOneIsInvalid and
-SafeHandleZeroOrMinusOneIsInvalid types in the Microsoft.Win32.SafeHandles
-namespace are there to help out here, returning true if the handle is the value
+`IsInvalid` property getter and return `true` or `false` to indicate whether the
+`SafeHandle` refers to an invalid handle. (The `SafeHandleMinusOneIsInvalid` and
+`SafeHandleZeroOrMinusOneIsInvalid` types in the `Microsoft.Win32.SafeHandles`
+namespace are there to help out here, returning `true` if the handle is the value
 -1 in the first case and true if the handle is the value -1 or 0 in the latter
 case. A PVOID with a value of 0 (i.e. NULL), for example, would be invalid for
-a handle to a memory address; SafeHandleZeroOrMinusOneIsInvalid would be
+a handle to a memory address; `SafeHandleZeroOrMinusOneIsInvalid` would be
 perfect for this.) ShawnFa [discusses implementing SafeHandle in more detail on
 his blog](http://blogs.msdn.com/shawnfa/archive/2004/08/12/213808.aspx).
 
-Your CriticalHandle and SafeHandle types should never take on additional
+Your `CriticalHandle` and `SafeHandle` types should never take on additional
 business-logic responsibility; make them as light-weight as possible, doing
 just enough to allocate and free resources. You'll probably have a number of
-other functional classes that make use of these handles. The Framework's Stream
-types are a classic example. Such types should implement the IDisposable
-interface and invoke Dispose on the underlying handle, providing an eager way
+other functional classes that make use of these handles. The Framework's `Stream`
+types are a classic example. Such types should implement the `IDisposable`
+interface and invoke `Dispose` on the underlying handle, providing an eager way
 to dispose of the resource. They should furthermore take care to never publicly
 expose the underlying handle, as doing so could be used to erroneously suppress
 finalization on a handle, leading to resource leaks.
 
-**Did you really mean never?**
+### Did you really mean never?
 
 Almost. There are still several situations in which people must still write
 complex finalizers. The tax they must pay for stepping outside of the simple
 allocate/deallocate pattern is understanding intimately [the big mess outlined
 here](http://www.bluebytesoftware.com/blog/PermaLink.aspx?guid=88e62cdf-5919-4ac7-bc33-20c06ae539ae).
 Most people should consider factoring their real cleanup code to use a
-SafeHandle, and only then layering specialized code on top of that inside of a
+`SafeHandle`, and only then layering specialized code on top of that inside of a
 normal finalizer.
 
 After a brief email thread with Chris Brumme, a number of legitimate cases of
@@ -164,70 +164,70 @@ alternative finalizer patterns were identified, including:
 
 1. Sophisticated APIs can use finalizers to return expensive objects—like
    large buffers or database connections—back to a pool, amortizing the cost
-of creating and destroying them over the life of the application.
-System.EnterpriseServices does this. This is one of the only cases where
-resurrection is an acceptable practice. Critical finalization should only be
-used here if resources are pooled across an entire process. Most resources are
-AppDomain-local, and thus do not qualify for CFO status.
+   of creating and destroying them over the life of the application.
+   `System.EnterpriseServices` does this. This is one of the only cases where
+   resurrection is an acceptable practice. Critical finalization should only be
+   used here if resources are pooled across an entire process. Most resources are
+   AppDomain-local, and thus do not qualify for CFO status.
 
-2. Calling GC.RemoveMemoryPressure to compensate for a previous
-   GC.AddMemoryPressure, used to communicate to the GC that the pressure
-associated with an object's resources is no longer a factor (because it's been
-cleaned up). This should be protected by a CFO if the resource whose pressure
-it tracks is also allocated/deallocated under a CFO. It's unfortunate that the
-RemoveMemoryPressure API doesn't make reliability guarantees (e.g. with
-ReliabilityContractAttribute). If it attempts to allocate memory—I can't
-imagine that it would—you could end up crashing the process due to an
-unhandled OutOfMemoryException. You could consider swallowing such exceptions,
-at the risk of violating the corruption contract. This is a crappy situation,
-but if a large quantity of pressure were leaked after an AppDomain unload, a
-skew could build up over time, affecting all parties in the process, precisely
-what we're trying to avoid by using CFOs. You need to make an intelligent
-tradeoff. We should fix this in a later release.
+2. Calling `GC.RemoveMemoryPressure` to compensate for a previous
+   `GC.AddMemoryPressure`, used to communicate to the GC that the pressure
+   associated with an object's resources is no longer a factor (because it's been
+   cleaned up). This should be protected by a CFO if the resource whose pressure
+   it tracks is also allocated/deallocated under a CFO. It's unfortunate that the
+   `RemoveMemoryPressure` API doesn't make reliability guarantees (e.g. with
+   `ReliabilityContractAttribute`). If it attempts to allocate memory—I can't
+   imagine that it would—you could end up crashing the process due to an
+   unhandled `OutOfMemoryException`. You could consider swallowing such exceptions,
+   at the risk of violating the corruption contract. This is a crappy situation,
+   but if a large quantity of pressure were leaked after an AppDomain unload, a
+   skew could build up over time, affecting all parties in the process, precisely
+   what we're trying to avoid by using CFOs. You need to make an intelligent
+   tradeoff. We should fix this in a later release.
 
 3. Incrementing or decrementing a performance counter or lighter-weight counter
    like a static field. This is often used to monitor the rate of
-creation/destruction of objects, and is often turned off in retail builds.
-Assuming imprecise counting is OK—e.g. if it's used only for testing
-purposes—this should not use a CFO. If you do use a CFO, you have you follow
-the guidelines above. For light-weight counters this is easy (i++ and i--
-traditionally don't allocate memory); but for performance counters it is not.
+   creation/destruction of objects, and is often turned off in retail builds.
+   Assuming imprecise counting is OK—e.g. if it's used only for testing
+   purposes—this should not use a CFO. If you do use a CFO, you have you follow
+   the guidelines above. For light-weight counters this is easy (i++ and i--
+   traditionally don't allocate memory); but for performance counters it is not.
 
 4. Asserting to find cases where an object should have been, but was not,
-   eagerly cleaned up using the IDisposable pattern. Properly written eager
-disposal is supposed to call GC.SuppressFinalization to eliminate the assert.
-It would be inappropriate to use CFOs for this purpose. Finally blocks will not
-run under a rude unload (which includes Dispose methods), and thus under any
-rude unload situation your CFO will fire.
+   eagerly cleaned up using the `IDisposable` pattern. Properly written eager
+   disposal is supposed to call `GC.SuppressFinalization` to eliminate the assert.
+   It would be inappropriate to use CFOs for this purpose. Finally blocks will not
+   run under a rude unload (which includes Dispose methods), and thus under any
+   rude unload situation your CFO will fire.
 
 5. Some external resources have elaborate rules for sequencing cleanup. The COM
    ADO APIs (not ADO.NET) require that fields are cleaned up before rows, which
-must precede tables, which must precede connections. If objects are cleaned up
-in a free-threaded manner or in the wrong order, memory corruption will occur.
-In other words, they violate the standard COM pUnk AddRef/Release rules.
-Outlook exposes COM APIs with similar sequencing rules. This is traditionally
-addressed by writing elaborate finalization code that walks the graph on the
-managed side and initiates the sequenced cleanup. This is the trickiest of all.
-If you can guarantee you follow the CFO rules outlined above, this probably
-belongs in a critical finalizer. But it's quite easy to make a misstep...you're
-basically playing with dynamite at this point.
+   must precede tables, which must precede connections. If objects are cleaned up
+   in a free-threaded manner or in the wrong order, memory corruption will occur.
+   In other words, they violate the standard COM pUnk AddRef/Release rules.
+   Outlook exposes COM APIs with similar sequencing rules. This is traditionally
+   addressed by writing elaborate finalization code that walks the graph on the
+   managed side and initiates the sequenced cleanup. This is the trickiest of all.
+   If you can guarantee you follow the CFO rules outlined above, this probably
+   belongs in a critical finalizer. But it's quite easy to make a misstep...you're
+   basically playing with dynamite at this point.
 
 If you decide you must write a finalizer, it's still important to follow [the
 pattern described
-here](http://www.bluebytesoftware.com/blog/PermaLink.aspx?guid=88e62cdf-5919-4ac7-bc33-20c06ae539ae),
+here](http://joeduffyblog.com/2005/04/08/dg-update-dispose-finalization-and-resource-management/),
 or the condensed version in the _ [.NET Framework Design
 Guidelines](http://www.amazon.com/exec/obidos/redirect?link_code=ur2&camp=1789&tag=bluebytesoftw-20&creative=9325&path=tg/detail/-/0321246756/qid=1123679961/sr=8-1/ref=sr_8_xs_ap_i1_xgl14?v=glance%26s=books%26n=507846)_
 book. This facilitates seamless integration with VC++ 2005's new destructor,
 Dispose, and finalization unification features.
 
-**Summary**
+### Summary
 
 At first glance, it appears that the world is simpler with CFOs. But when you
 consider that you have to abide by the same rules for normal finalizers plus
 the new ornery CER rules, life still isn't very simple at all.
-CriticalFinalizerObject makes sure your resources don't leak during hostile
-takeovers, and SafeHandle makes life more secure and a little easier in that
-the plumbing required to get IDisposable hooked up is all built for you, but
+`CriticalFinalizerObject` makes sure your resources don't leak during hostile
+takeovers, and `SafeHandle` makes life more secure and a little easier in that
+the plumbing required to get `IDisposable` hooked up is all built for you, but
 one thing remains the same: Interoperating with unmanaged code is tricky stuff.
 But thankfully [the world will be written in nothing but managed code sometime
 in the near future](http://channel9.msdn.com/Showpost.aspx?postid=141858). Then

--- a/_posts/2006-01-07-coroutines-using-threads-and-events.md
+++ b/_posts/2006-01-07-coroutines-using-threads-and-events.md
@@ -56,744 +56,205 @@ thread-per-coroutine approach mentioned above. Up front, I have to warn you: I
 spent 30 minutes on this thing. It's bound to be buggy, and I took some
 shortcuts (like not implementing the respective collections interfaces). Rather
 than walking through bit-by-bit, I've tried to comment the source code to
-explain how it works:
+plain how it works:
 
-> **using** System;
->
->
->
-> **using** SD = System.Diagnostics;
->
->
->
-> **using** System.Threading;
->
->
->
->
->
->
->
-> **public**  **delegate**  **void** CoroutineStart();
->
->
->
->
->
->
->
-> **public**  **class** Coroutine<T> : IDisposable
->
->
->
-> {
->
->
->
->     // Fields
->
->
->
->     **private** CoroutineStart start;
->
->
->
->     **private** Thread thread;
->
->
->
->     **private** AutoResetEvent computeNextEvent;
->
->
->
->     **private** AutoResetEvent nextAvailableEvent;
->
->
->
->     **private** ManualResetEvent doneEvent;
->
->
->
->     **private** T current;
->
->
->
->
->
->
->
->     // We have a thread-static here so the coroutine needn't track the
->     Coroutine<T> object
->
->
->
->     // manually. The Yield function is static, so they can just call
->     Coroutine.Yield(v);
->
->
->
->     [ThreadStatic]
->
->
->
->     **private**  **static** Coroutine<T> coroutine;
->
->
->
->
->
->
->
->     // Constructors
->
->
->
->     **public** Coroutine(CoroutineStart start)
->
->
->
->     {
->
->
->
->         **this**.start = start;
->
->
->
->         **this**.thread = **new** Thread(Worker);
->
->
->
->         **this**.computeNextEvent = **new** AutoResetEvent( **false** );
->
->
->
->         **this**.nextAvailableEvent = **new** AutoResetEvent( **false** );
->
->
->
->         **this**.doneEvent = **new** ManualResetEvent( **false** );
->
->
->
->     }
->
->
->
->
->
->
->
->     // Properties
->
->
->
->     **public** T Current
->
->
->
->     {
->
->
->
->         // TODO: we could add some error checking here, e.g. if somebody
->         tries to
->
->
->
->         // read past the end-of-stream.
->
->
->
->         **get** { **return** current; }
->
->
->
->     }
->
->
->
->
->
->
->
->     // Methods
->
->
->
->     **public**  **bool** MoveNext()
->
->
->
->     {
->
->
->
->         **if** (thread.ThreadState == ThreadState.Unstarted)
->
->
->
->             thread.Start();
->
->
->
->         **else**
->
->
->
->             computeNextEvent.Set();
->
->
->
->
->
->
->
->         // We wait on the 'next available' and 'done' events simultaneously.
->         And then
->
->
->
->         // we use this to determine whether the coroutine has finished or
->         not. The consumer
->
->
->
->         // will typically use this in a loop, e.g. while (c.MoveNext()) {
->         f(c.Current); }.
->
->
->
->         **return** (0 ==
->
->
->
->             WaitHandle.WaitAny( **new** WaitHandle[] { nextAvailableEvent,
->             doneEvent }));
->
->
->
->     }
->
->
->
->
->
->
->
->     **private**  **void** Worker()
->
->
->
->     {
->
->
->
->         **try**
->
->
->
->         {
->
->
->
->             // Stash the coroutine object in TLS and start the CoroutineStart
->             routine.
->
->
->
->             coroutine = **this** ;
->
->
->
->             start();
->
->
->
->         }
->
->
->
->         **catch** (ThreadInterruptedException)
->
->
->
->         {
->
->
->
->             // Ignore the interrupt request. We use this as the 'proper' way
->             to shut-down
->
->
->
->             // a couroutine. This is really a hack. Needs to be revisited.
->
->
->
->         }
->
->
->
->         **finally**
->
->
->
->         {
->
->
->
->             // Lastly, signal to the caller that the coroutine is done
->             producing. Note that
->
->
->
->             // we'd ideally just use the thread executive object directly.
->             But unfortunately the
->
->
->
->             // managed thread class doesn't expose this WaitHandle. :(
->
->
->
->             doneEvent.Set();
->
->
->
->         }
->
->
->
->     }
->
->
->
->
->
->
->
->     **public**  **static**  **void** Yield(T value)
->
->
->
->     {
->
->
->
->         Coroutine<T> c = coroutine;
->
->
->
->
->
->
->
->         // First, ensure we're on a coroutine thread.
->
->
->
->         **if** (c == **null** )
->
->
->
->             **throw**  **new** InvalidOperationException("You can only yield
->             from a coroutine thread");
->
->
->
->
->
->
->
->         // Now, set the coroutine's current value to the argument, signal to
->         the consumer
->
->
->
->         // that we have a new item, and go to sleep until we're asked to
->         compute the next item.
->
->
->
->         c.current = value;
->
->
->
->         c.nextAvailableEvent.Set();
->
->
->
->         c.computeNextEvent.WaitOne();
->
->
->
->     }
->
->
->
->
->
->
->
->     **public**  **void** Dispose()
->
->
->
->     {
->
->
->
->         // We ensure the thread has stopped here. We use a really ugly
->         interrupt to bring
->
->
->
->         // it down if not.
->
->
->
->         **if** (thread.ThreadState != ThreadState.Aborted &&
->
->
->
->             thread.ThreadState != ThreadState.Stopped &&
->
->
->
->             thread.ThreadState != ThreadState.Unstarted)
->
->
->
->         {
->
->
->
->             SD.Trace.TraceWarning("Coroutine thread has not stopped when
->             Disposing, in state {0}",
->
->
->
->                 thread.ThreadState);
->
->
->
->             thread.Interrupt();
->
->
->
->             // Joining here is questionable at best. It could lead to
->             deadlocks.
->
->
->
->             thread.Join();
->
->
->
->         }
->
->
->
->
->
->
->
->         // Close out all of the events.
->
->
->
->         computeNextEvent.Close();
->
->
->
->         nextAvailableEvent.Close();
->
->
->
->         doneEvent.Close();
->
->
->
->     }
->
->
->
-> }
->
->
->
->
->
->
->
-> **public**  **static**  **class** Coroutine
->
->
->
-> {
->
->
->
->     // This is a trick. The C# compiler will infer the method argument <T>,
->     enabling
->
->
->
->     // us to shunt right over to the Coroutine<T> implementation. This is
->     nice because
->
->
->
->     // the user can just write Coroutine.Yield(n) instead of
->     Coroutine<T>.Yield(n). The
->
->
->
->     // annoying part is that you can easily yield something of the wrong
->     type, leading to
->
->
->
->     // an IllegalOperationException because C<T>.Yield will look in TLS and
->     not find anything.
->
->
->
->     **public**  **static**  **void** Yield<T>(T t)
->
->
->
->     {
->
->
->
->         Coroutine<T>.Yield(t);
->
->
->
->     }
->
->
->
-> }
+    using System;
+    using SD = System.Diagnostics;
+    using System.Threading;
 
-Now let's see it in action. Given a function Fibonacci, which continuously
+    public delegate void CoroutineStart();
+    
+    public class Coroutine<T> : IDisposable
+    {
+      // Fields
+      private CoroutineStart start;
+      private Thread thread;
+      private AutoResetEvent computeNextEvent;
+      private AutoResetEvent nextAvailableEvent;
+      private ManualResetEvent doneEvent;
+      private T current;
+
+      // We have a thread-static here so the coroutine needn't track the Coroutine<T> object
+      // manually. The Yield function is static, so they can just call Coroutine.Yield(v);
+      [ThreadStatic]
+      private static Coroutine<T> coroutine
+
+      // Constructors
+      public Coroutine(CoroutineStart start)
+      {
+          this.start = start;
+          this.thread = new Thread(Worker);
+          this.computeNextEvent = new AutoResetEvent(false);
+          this.nextAvailableEvent = new AutoResetEvent(false);
+          this.doneEvent = new ManualResetEvent(false);
+      }
+
+      // Properties
+      public T Current
+      {
+          // TODO: we could add some error checking here, e.g. if somebody tries to
+          // read past the end-of-stream.
+          get { return current; }
+      }
+
+      // Methods
+      public bool MoveNext()
+      {
+        if (thread.ThreadState == ThreadState.Unstarted)
+          thread.Start();
+        else
+          computeNextEvent.Set();
+
+        // We wait on the 'next available' and 'done' events simultaneously. And then
+        // we use this to determine whether the coroutine has finished ornot. The consumer
+        // will typically use this in a loop, e.g. while (c.MoveNext()) {f(c.Current); }.
+        return (0 == WaitHandle.WaitAny(new WaitHandle[] { nextAvailableEvent, doneEvent }));
+      }
+
+      private void Worker()
+      {
+        try
+        {
+          // Stash the coroutine object in TLS and start the CoroutineStart routine.
+          coroutine = this;
+          start();
+        }
+        catch (ThreadInterruptedException)
+        {
+          // Ignore the interrupt request. We use this as the 'proper' way to shut-down
+          // a couroutine. This is really a hack. Needs to be revisited.
+        }
+        finally
+        {
+          // Lastly, signal to the caller that the coroutine is done producing. Note that
+          // we'd ideally just use the thread executive object directly. But unfortunately the
+          // managed thread class doesn't expose this WaitHandle. :(
+          doneEvent.Set();
+        }
+      }
+
+      public static void Yield(T value)
+      {
+        Coroutine<T> c = coroutine;
+
+        // First, ensure we're on a coroutine thread.
+        if (c == null)
+          throw new InvalidOperationException("You can only yield from a coroutine thread");
+
+        // Now, set the coroutine's current value to the argument, signal to the consumer
+        // that we have a new item, and go to sleep until we're asked to compute the next item.
+
+        c.current = value;
+        c.nextAvailableEvent.Set();
+        c.computeNextEvent.WaitOne();
+      }
+
+      public void Dispose()
+      {
+        // We ensure the thread has stopped here. We use a really ugly interrupt to bring
+        // it down if not.
+        if (thread.ThreadState != ThreadState.Aborted &&
+            thread.ThreadState != ThreadState.Stopped &&
+            thread.ThreadState != ThreadState.Unstarted)
+        {
+          SD.Trace.TraceWarning(
+            "Coroutine thread has not stopped when Disposing, in state {0}",
+            thread.ThreadState);
+
+          thread.Interrupt();
+
+          // Joining here is questionable at best. It could lead to deadlocks.
+          thread.Join();
+        }
+
+        // Close out all of the events.
+        computeNextEvent.Close();
+        nextAvailableEvent.Close();
+        doneEvent.Close();
+      }
+    }
+
+    public static class Coroutine
+    {
+      // This is a trick. The C# compiler will infer the method argument <T>, enabling
+      // us to shunt right over to the Coroutine<T> implementation. This is nice because
+      // the user can just write Coroutine.Yield(n) instead of Coroutine<T>.Yield(n). The
+      // annoying part is that you can easily yield something of the wrong type, leading to
+      // an IllegalOperationException because C<T>.Yield will look in TLS and not find anything.
+      public static void Yield<T>(T t) { Coroutine<T>.Yield(t); }
+    }
+
+Now let's see it in action. Given a function `Fibonacci`, which continuously
 yields the next item in the Fibonacci sequence:
 
-> **void** Fibonnaci()
->
->
->
-> {
->
->
->
->     **long** n0 = 0;
->
->
->
->     **long** n1 = 1;
->
->
->
->
->
->
->
->     **long** n;
->
->
->
->     **while** ( **true** )
->
->
->
->     {
->
->
->
->         n = n0 + n1;
->
->
->
->         n0 = n1;
->
->
->
->         n1 = n;
->
->
->
->         Coroutine.Yield(n);
->
->
->
->     }
->
->
->
-> }
+    void Fibonnaci()
+    {
+      long n0 = 0;
+      long n1 = 1;
+      long n;
+
+      while (true)
+      {
+        n = n0 + n1;
+        n0 = n1;
+        n1 = n;
+
+        Coroutine.Yield(n);
+      }
+    }
 
 We can form a coroutine over it and scroll through the first 10 numbers:
 
-> **using** (Coroutine< **long** > c = **new** Coroutine< **long**
-> >(Fibonnaci))
->
->
->
-> {
->
->
->
->     **int** i = 0;
->
->
->
->     **while** (c.MoveNext() && i++ < 10)
->
->
->
->         Console.WriteLine(c.Current);
->
->
->
-> }
+    using (Coroutine<long> c = new Coroutine<long>(Fibonnaci))
+    {
+      int i = 0;
+
+      while (c.MoveNext() && i++ < 10)
+        Console.WriteLine(c.Current);
+    }
 
 And of course, we can create a coroutine over a function that yields from
 functions deep in the call stack:
 
-> **void** a()
->
->
->
-> {
->
->
->
->     Coroutine.Yield("a");
->
->
->
->     b();
->
->
->
->     e();
->
->
->
-> }
->
->
->
->
->
->
->
-> **void** b()
->
->
->
-> {
->
->
->
->     Coroutine.Yield("a.b");
->
->
->
->     c();
->
->
->
-> }
->
->
->
->
->
->
->
-> **void** c()
->
->
->
-> {
->
->
->
->     Coroutine.Yield("a.b.c");
->
->
->
->     d();
->
->
->
-> }
->
->
->
->
->
->
->
-> **void** d()
->
->
->
-> {
->
->
->
->     Coroutine.Yield("a.b.c.d");
->
->
->
-> }
->
->
->
->
->
->
->
-> **void** e()
->
->
->
-> {
->
->
->
->     Coroutine.Yield("e");
->
->
->
-> }
+    void a()
+    {
+      Coroutine.Yield("a");
+
+      b();
+      e();
+    }
+
+    void b()
+    {
+      Coroutine.Yield("a.b");
+      c();
+    }
+
+    void c()
+    {
+      Coroutine.Yield("a.b.c");
+      d();
+    }
+
+    void d()
+    {
+      Coroutine.Yield("a.b.c.d");
+    }
+
+    void e()
+    {
+      Coroutine.Yield("e");
+    }
 
 And iterate over it:
 
-> **using** (Coroutine< **string** > c = **new** Coroutine< **string** >(a))
->
->
->
-> {
->
->
->
->     **while** (c.MoveNext())
->
->
->
->         Console.WriteLine(c.Current);
->
->
->
-> }
+    using (Coroutine<string> c = new Coroutine<string>(a))
+    {
+      while (c.MoveNext())
+        Console.WriteLine(c.Current);
+    }
 
-A neat extension to this whole idea might be a BeginMoveNext function that
+A neat extension to this whole idea might be a `BeginMoveNext` function that
 follows the asynchronous programming model. You could then exploit the fact
 that the consumer and producer are on separate threads to make progress while
 the producer is calculating the next item in line. Assuming you're on a

--- a/_posts/2006-01-26-broken-variants-on-doublechecked-locking.md
+++ b/_posts/2006-01-26-broken-variants-on-doublechecked-locking.md
@@ -33,58 +33,77 @@ These modifications not only enable the double checked locking pattern, but
 also prevent constructors from publishing the newly allocated object before
 their state has been initialized, as I mentioned in my PDC presentation on
 concurrency last year. We accomplish this by ensuring writes have 'release'
-semantics on IA-64, via the st.rel instruction. A single _st.rel x_ guarantees
+semantics on IA-64, via the `st.rel` instruction. A single `st.rel x` guarantees
 that any other loads and stores leading up to its execution (in the physical
 instruction stream) must have appeared to have occurred to each logical
-processor at least by the time _x_'s new value becomes visible to another
-logical processor. Loads can be given 'acquire' semantics (via the ld.acq
+processor at least by the time `x`'s new value becomes visible to another
+logical processor. Loads can be given 'acquire' semantics (via the `ld.acq`
 instruction), meaning that any other loads and stores that occur after a
-_ld.acq x_ cannot appear to have occurred prior to the load. The 2.0 memory
-model does not use ld.acq's unless you are accessing volatile data (marked w/
-the volatile modifier keyword or accessed via the Thread.VolatileRead API).
+`ld.acq x` cannot appear to have occurred prior to the load. The 2.0 memory
+model does not use `ld.acq`'s unless you are accessing volatile data (marked w/
+the `volatile` modifier keyword or accessed via the `Thread.VolatileRead` API).
 This can lead to some subtle problems.
 
 For example, a slight variant of the double checked lock will not work under
 our model:
 
-> class Singleton { private static object slock = new object(); private static
-> Singleton instance; private static bool initialized; private Singleton() {}
-> public Instance { get { if (!initialized) { lock (slock) { if (!initialized)
-> { instance = new Singleton(); initialized = true; } } } return instance; } }
-> }
+    class Singleton
+    {
+      private static object slock = new object();
+      private static Singleton instance;
+      private static bool initialized;
+
+      private Singleton() {}
+      public Instance
+      {
+        get
+        {
+          if (!initialized)
+          {
+            lock (slock)
+            {
+              if (!initialized)
+              {
+                instance = new Singleton();
+                initialized = true;
+              }
+            }
+          }
+          return instance;
+        }
+      }
+    }
 
 You might have decided to use this pattern to determine whether to initialize a
 value-type, since checking the variable for null isn't possible. If you had
-some more complex set of state, perhaps you want to use a single Boolean rather
+some more complex set of state, perhaps you want to use a single `Boolean` rather
 than checking, say, 10 separate variables to see if they have each been
 initialized. Whatever your reasoning, as written the above code is prone to a
 subtle race condition.
 
-The problem here is that both reads of initialized and instance do not have
+The problem here is that both reads of `initialized` and `instance` do not have
 'acquire' semantics. Thus, instance could appear to have been read before
 initialized, e.g. as follows:
 
 | **Time** | **Thread A** | **Thread B** |
-
-| 0 | | Reads instance as null |
-
-| 1 | Reads initialized as false |
-
-| 2 | Sets instance to ref to new obj |
-
-| 3 | Sets initialized to true |
-
-| 4 | Uses instance (initialized) |
-
-| 5 | | Reads initialized as true |
-
-| 6 | | Uses instance (null!) |
+-----------|--------------|--------------|
+| 0        |                                  | Reads instance as null    |
+| 1        | Reads initialized as false       |
+| 2        | Sets instance to ref to new obj  |
+| 3        | Sets initialized to true         |
+| 4        | Uses instance (initialized)      |
+| 5        |                                  | Reads initialized as true |
+| 6        |                                  | Uses instance (null!)     |
 
 Thread B ends up returning a null reference. If a caller tried to use it, they
-might encounter a spurious NullReferenceException, the cause of which is
+might encounter a spurious `NullReferenceException`, the cause of which is
 incredibly hard to debug. For example:
 
-> void f() { Singleton s = Singleton.Instance; s.DoSomething(); // Boom!  }
+    void f()
+    {
+      Singleton s = Singleton.Instance;
+      s.DoSomething(); // Boom!
+    }
 
 For this to have happened, Thread B would have had to read instance entirely
 out of order. It might have done so for any number of reasons. If it recently
@@ -95,8 +114,8 @@ the load was moved before the load of initialized. Or superscalar execution
 might perform branch prediction and retrieve the value of instance, assuming
 that initialized will be false, pulling it into cache ahead of the read of
 initialized. Again, because it is a non-acquire read, this is a valid thing to
-do. If it reads initialized as true, its prediction was actually correct, and
-it just returns the null value that was pre-fetched. It might even be the case
+do. If it reads `initialized` as `true`, its prediction was actually correct, and
+it just returns the `null` value that was pre-fetched. It might even be the case
 that a compiler along the way moved the read, which is also entirely legal with
 our memory model.
 
@@ -105,15 +124,36 @@ of the initialized variable, prohibiting the read of instance from moving prior
 to the read of initialized. Control dependency prevents us from having to use a
 volatile-read for the reads of both variables.
 
-> class Singleton { private static object slock = new object(); private static
-> Singleton instance; private static int initialized; private Singleton() {}
-> public Instance { get { if (Thread.VolatileRead(ref initialized) == 0) { lock
-> (slock) { if (initialized == 0) { instance = new Singleton(); initialized =
-> 1; } } } return instance; } } }
+    class Singleton
+    {
+      private static object slock = new object();
+      private static Singleton instance;
+      private static int initialized;
 
-You could have instead inserted a call to Thread.MemoryBarrier instead, which
+      private Singleton() {}
+      public Instance
+      {
+        get
+        {
+          if (Thread.VolatileRead(ref initialized) == 0)
+          {
+            lock (slock)
+            {
+              if (initialized == 0)
+              {
+                instance = new Singleton();
+                initialized = 1;
+              }
+            }
+          }
+          return instance;
+        }
+      }
+    }
+
+You could have instead inserted a call to `Thread.MemoryBarrier` instead, which
 is a two way memory-fence, in between if-block and the read of instance, but
-the cost of a barrier is generally higher than both a st.rel and ld.acq because
+the cost of a barrier is generally higher than both a `st.rel` and `ld.acq` because
 it affects surrounding instructions and movement in both directions.
 
 The take-away here is not that you must understand the specifics of how cache

--- a/_posts/2006-02-07-threadsafety-torn-reads-and-the-like.md
+++ b/_posts/2006-02-07-threadsafety-torn-reads-and-the-like.md
@@ -25,20 +25,22 @@ any good central explanation of its meaning and any caveats.
 It's relatively difficult to make such a statement. The .NET Framework is
 generally written so that all static members are thread-safe, while instance
 members are not. There are some notable exceptions, mostly to do with immutable
-types (e.g. the primitives, System.DateTime, System.Type, etc.), but they are
+types (e.g. the primitives, `System.DateTime`, `System.Type`, etc.), but they are
 infrequent.
 
 This brings me to the types of thread safety issues we're generally concerned
 with.
 
 The first problem is torn reads and writes. Operations that deal with data
-whose size is greater than the native machine-sized pointer (i.e.
-sizeof(void\*)) are not atomic in the ISA. This applies to 64-bit operations on
+whose size is greater than the native machine-sized pointer (i.e. `sizeof(void*)`)
+are not atomic in the ISA. This applies to 64-bit operations on
 32-bit platforms, 128-bit on 64-bit, etc. We happen to provide you two
-intrinsic 64-bit types—Int64 (C# long) and Double (C# double)—which makes
+intrinsic 64-bit types—`Int64` (C# `long`) and `Double` (C# `double`)—which makes
 this issue a tad tricky. So this code
 
-> static long x; // … x = 1111222233334444;
+    static long x;
+    // …
+    x = 1111222233334444;
 
 consists of two DWORD MOVs at the machine level, one to the most significant
 half and then the least significant half (in that order, at least in the
@@ -46,18 +48,18 @@ Whidbey x86 JIT). Reads likewise involve two MOV instructions.
 
 If you're doing naked reads and writes with such values, instructions can be
 interleaved such that only one DWORD has been written. That means a thread
-racing with the above assignment can see x with a value of (x &
+racing with the above assignment can see `x` with a value of (x &
 0xFFFFFFFF00000000), or 2524709548 in decimal. This is obviously surprising, as
 the two values (at first glance) don't seem to be related. And this same
 principle applies to reads and writes of any value type instances whose size is
-greater than sizeof(void\*).
+greater than `sizeof(void*)`.
 
 This can be solved by protecting all access to the data under a lock or via an
-interlocked operation. Interlocked.Exchange will do the trick for writes, and
-Interlocked.Read for reads. Note that most platforms offer 128-bit interlocked
+interlocked operation. `Interlocked.Exchange` will do the trick for writes, and
+`Interlocked.Read` for reads. Note that most platforms offer 128-bit interlocked
 instructions. Unfortunately, because of the platform-specificity, the Win32
 APIs and our System.Threading APIs don't broadly support them. Hopefully this
-changes over time. For the same reason you often need two void\*-sized writes
+changes over time. For the same reason you often need two `void*`-sized writes
 on 32-bit, you often need the same on 64-bit.
 
 In summary, any type that exposes a writable 64-bit field, or which returns a
@@ -72,7 +74,7 @@ writes can be multiple instructions long, it should be clear that by default a
 read/modify/write is at least three. For a 64-bit value on a 32-bit platform,
 it's six. At any point in that invocation, interleaved execution can cause an
 update to go missing. The solution here, again, is to do this inside a lock.
-The Interlocked.CompareExchange function is great for this purpose, as it takes
+The `Interlocked.CompareExchange` function is great for this purpose, as it takes
 advantage of hardware-level read/modify/write instructions. Thankfully they are
 supported by all modern hardware ISAs.
 

--- a/_posts/2006-02-23-stas-pumping-and-the-ui.md
+++ b/_posts/2006-02-23-stas-pumping-and-the-ui.md
@@ -18,8 +18,8 @@ author:
   last_name: ''
 ---
 When you perform a wait on the CLR, we make sure it happens in an STA-friendly
-manner. This entails using msg-waits, such as MsgWaitForMultipleObjectsEx
-and/or CoWaitForMultipleHandles. Doing so ensures we pick up and dispatch
+manner. This entails using msg-waits, such as `MsgWaitForMultipleObjectsEx`
+and/or `CoWaitForMultipleHandles`. Doing so ensures we pick up and dispatch
 incoming RPC work mid-stack, while the STA isn't necessarily sitting in a
 top-level message loop. In fact, an STA that doesn't pump temporarily can
 easily lead to temporary and permanent hangs (i.e. deadlocks), especially in
@@ -37,7 +37,7 @@ pump the special "WIN95 RPC Wmsg", "OleMainThreadWndClass", and
 
 If you were on a UI and you pumped your window's message queue, you could end
 up dispatching new events before old events had completed. If you dispatched a
-WM\_CLOSE message on the same stack you were doing some other UI processing,
+`WM_CLOSE` message on the same stack you were doing some other UI processing,
 you'd destroy the window before that other processing was done. Without the GUI
 message loop taking this into account somehow, you'd crash. There are other
 factors. Imagine you were processing a click event that required movement of

--- a/_posts/2006-03-25-a-stopwatch-for-threads.md
+++ b/_posts/2006-03-25-a-stopwatch-for-threads.md
@@ -34,466 +34,276 @@ So I whipped up a stopwatch that maintains a counter that is the cumulative
 total of all threads that have started/stopped it, across an entire AppDomain.
 It's nothing incredibly clever, but I've found it to be quite useful. In many
 code projects I have, I've simply set up a file that declares a bunch of static
-ThreadSafeStopwatches, which I can then just call from anywhere.
+`ThreadSafeStopwatches`, which I can then just call from anywhere.
 
 Here's the code (also available for download here:
 [ThreadSafeStopwatch.cs](http://www.bluebytesoftware.com/code/06/03/ThreadsafeStopwatch.cs)):
 
-using System;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
 
-using System.Collections.Generic;
-
-using System.Diagnostics;
-
-using System.Threading;
-
-/// <summary>
-
-/// This class enables AppDomain-wide profiling of multi-threaded
-
-/// code, by tracking a cumulative number of ticks spent across all
-
-/// threads. If multiple threads start the same watch in parallel,
-
-/// this class ensures that we count time for both threads, and that
-
-/// they do not interfere with each other. It does this by storing an
-
-/// internal stop-watch in TLS, and an instance-wide tick counter.
-
-///
-
-/// Note that the cumulative count is only ever incremented if a
-
-/// thread actually calls Stop in its own stop-watch. If a thread
-
-/// routine terminates w/out stopping the watch, it's as if it never
-
-/// began.
-
-/// </summary>
-
-public sealed class ThreadSafeStopwatch : IDisposable
-
-{
-
-    /\*\* Fields \*\*/
-
-    private long ticks;
-
-    // These thread-specific fields are used to maintain a cache
-
-    // of thread-safe stopwatches to actual stopwatches. For long
-
-    // running threads, we can build up some amount of trash over
-
-    // time, so a cache management scheme is implemented via a
-
-    // combination of mechanisms: Dispose, ~ThreadSafeStopwatch,
-
-    // GetWatch, and PruneCache.
-
-    [ThreadStatic]
-
-    private static Dictionary<WeakReference, Stopwatch> threadWatches;
-
-    [ThreadStatic]
-
-    private static int cacheCounter;
-
-    /\*\* Properties \*\*/
-
-    public long ElapsedTicks
-
+    /// <summary>
+    /// This class enables AppDomain-wide profiling of multi-threaded
+    /// code, by tracking a cumulative number of ticks spent across all
+    /// threads. If multiple threads start the same watch in parallel,
+    /// this class ensures that we count time for both threads, and that
+    /// they do not interfere with each other. It does this by storing an
+    /// internal stop-watch in TLS, and an instance-wide tick counter.
+    ///
+    /// Note that the cumulative count is only ever incremented if a
+    /// thread actually calls Stop in its own stop-watch. If a thread
+    /// routine terminates w/out stopping the watch, it's as if it never
+    /// began.
+    /// </summary>
+    public sealed class ThreadSafeStopwatch : IDisposable
     {
+      // Fields
+      private long ticks;
 
-        get { return ticks; }
+      // These thread-specific fields are used to maintain a cache
+      // of thread-safe stopwatches to actual stopwatches. For long
+      // running threads, we can build up some amount of trash over
+      // time, so a cache management scheme is implemented via a
+      // combination of mechanisms: Dispose, ~ThreadSafeStopwatch,
+      // GetWatch, and PruneCache.
 
-    }
+      [ThreadStatic]
+      private static Dictionary<WeakReference, Stopwatch> threadWatches;
 
-    public float ElapsedMilliseconds
+      [ThreadStatic]
+      private static int cacheCounter;
 
-    {
+      // Properties
+      public long ElapsedTick { get { return ticks; } }
 
+      public float ElapsedMilliseconds
+      {
         get { return (float)ticks / TimeSpan.TicksPerMillisecond; }
+      }
 
-    }
-
-    /\*\* Methods \*\*/
-
-    ~ThreadSafeStopwatch()
-
-    {
-
-        Dispose(false);
-
-    }
-
-    public void Dispose()
-
-    {
-
-        Dispose(true);
-
-    }
+      // Methods
+    ~ThreadSafeStopwatch() { Dispose(false); }
+    public void Dispose() { Dispose(true); }
 
     private void Dispose(bool disposing)
-
     {
+      // Clean up the associated cache entry with this object.
+      // NOTE: I am explicitly not guarding this code-path by if
+      // (disposing) { ... } because the Dictionary is not finaliz-
+      // able. Thus, I know it is safe to access it. In the case of
+      // non-process-exit finalizers, we do want to clean up the
+      // associated cache entry, thus we access another object on
+      // the finalizer code-path.
 
-        // Clean up the associated cache entry with this object.
+      if (!Environment.HasShutdownStarted)
+      {
+        Dictionary<WeakReference, Stopwatch> watches = threadWatches;
 
-        // NOTE: I am explicitly not guarding this code-path by if
-
-        // (disposing) { ... } because the Dictionary is not finaliz-
-
-        // able. Thus, I know it is safe to access it. In the case of
-
-        // non-process-exit finalizers, we do want to clean up the
-
-        // associated cache entry, thus we access another object on
-
-        // the finalizer code-path.
-
-        if (!Environment.HasShutdownStarted)
-
+        WeakReference thisRef = new WeakReference(this);
+        if (watches != null && watches.ContainsKey(thisRef))
         {
-
-            Dictionary<WeakReference, Stopwatch> watches = threadWatches;
-
-            WeakReference thisRef = new WeakReference(this);
-
-            if (watches != null && watches.ContainsKey(thisRef))
-
-            {
-
-                // Deallocate the cache entry:
-
-                watches.Remove(thisRef);
-
-            }
-
+          // Deallocate the cache entry:
+          watches.Remove(thisRef);
         }
-
+      }
     }
 
     const int threadCachePruneCount = 100;
 
     private Stopwatch GetWatch()
-
     {
-
         if (threadWatches == null)
-
         {
-
-            // First time called on this thread, allocate a new dictionary:
-
-            threadWatches = new Dictionary<WeakReference, Stopwatch>(
-
-                WeakRefEqualityComparer.Comparer);
-
+          // First time called on this thread, allocate a new dictionary:
+          threadWatches = new Dictionary<WeakReference, Stopwatch>(
+            WeakRefEqualityComparer.Comparer);
         }
-
         else
-
         {
-
-            // This has been called before. Increment the thread counter;
-
-            // every so often, we prune out trash being held alive by our
-
-            // cache.
-
-            if (++cacheCounter % threadCachePruneCount == 0)
-
-            {
-
-                PruneCache();
-
-                cacheCounter = 0;
-
-            }
-
+          // This has been called before. Increment the thread counter;
+          // every so often, we prune out trash being held alive by our
+          // cache.
+          if (++cacheCounter % threadCachePruneCount == 0)
+          {
+            PruneCache();
+            cacheCounter = 0;
+          }
         }
 
         // Now look for the associated stopwatch:
-
         Stopwatch sw;
-
         if (threadWatches.TryGetValue(new WeakReference(this), out sw))
-
-            return sw;
+          return sw;
 
         // If we didn't find the stopwatch, simply return null to
-
         // indicate that the caller needs to allocate a new one:
 
         return null;
+      }
 
-    }
-
-    private void PruneCache()
-
-    {
-
+      private void PruneCache()
+      {
         // BUGBUG: This is probably a poor cache management policy. But
-
         // I'm only enabling this in DEBUG builds for now, and until I
-
         // run into a real problem, I'm not spending time on it.
 
         List<WeakReference> toRemoveWrefs = null;
 
         // Look for dead references, and add them to the list (which is
-
         // lazily created, by the way).
 
         foreach (WeakReference wr in threadWatches.Keys)
-
         {
-
-            // If the weak-reference is no longer alive, we add it to the
-
-            // list of 'to-remove' stop-watches.
-
-            if (!wr.IsAlive)
-
-            {
-
-                if (toRemoveWrefs == null)
-
-                    toRemoveWrefs = new List<WeakReference>();
-
-                toRemoveWrefs.Add(wr);
-
-            }
-
+          // If the weak-reference is no longer alive, we add it to the
+          // list of 'to-remove' stop-watches.
+          if (!wr.IsAlive)
+          {
+            if (toRemoveWrefs == null)
+              toRemoveWrefs = new List<WeakReference>();
+            toRemoveWrefs.Add(wr);
+          }
         }
 
         // If we found any dead entries, remove them now.
-
         if (toRemoveWrefs != null)
-
         {
-
-            foreach (WeakReference wr in toRemoveWrefs)
-
-            {
-
-                threadWatches.Remove(wr);
-
-            }
-
+          foreach (WeakReference wr in toRemoveWrefs)
+          {
+            threadWatches.Remove(wr);
+          }
         }
+      }
 
-    }
-
-    [Conditional("DEBUG")]
-
-    public void Start()
-
-    {
-
+      [Conditional("DEBUG")]
+      public void Start()
+      {
         // We look in TLS to see if this thread has already allocated a
-
         // stopwatch for the current thread-safe stopwatch. This is
-
         // thread-safe, of course, since each thread gets their own list
-
         // of Stopwatches (reentrancy aside--there aren't any blocking
-
         // points below):
-
         // Since we are about to retrieve something from TLS, and use it
-
         // across a set of paired operations (Start/Stop), we mark the
-
         // beginning of a thread-affinity region.
 
         Thread.BeginThreadAffinity();
 
         // Access TLS:
-
         Stopwatch sw = GetWatch();
 
         if (sw == null)
-
         {
+          // No watch was found, allocate a new one and publish it.
+          sw = new Stopwatch();
 
-            // No watch was found, allocate a new one and publish it.
-
-            sw = new Stopwatch();
-
-            threadWatches.Add(new WeakReference(this), sw);
-
+          threadWatches.Add(new WeakReference(this), sw);
         }
 
         // First, ensure we haven't begun it yet. If the stopwatch is
-
-        // already running, we ignore this call. This is consistent with
-
-        the System.Diagnostics.Stopwatch
-
+        // already running, we ignore this call. This is consistent with the System.Diagnostics.Stopwatch
         // class's behavior.
 
         if (!sw.IsRunning)
-
         {
-
-            // And if that check succeeds, start the stop-watch ticking.
-
-            sw.Start();
-
+          // And if that check succeeds, start the stop-watch ticking.
+          sw.Start();
         }
+      }
 
-    }
-
-    [Conditional("DEBUG")]
-
-    public void Reset()
-
-    {
-
+      [Conditional("DEBUG")]
+      public void Reset()
+      {
         // Get the current stopwatch in TLS -- see above comments (in
-
         // Start) for details on thread-safety.
-
         Stopwatch sw = GetWatch();
 
         // If we found one, reset it.
-
         if (sw != null)
-
-            sw.Reset();
+          sw.Reset();
 
         // And also set our cumulative ticks to 0.
-
         ticks = 0;
+      }
 
-    }
-
-    [Conditional("DEBUG")]
-
-    public void Stop()
-
-    {
-
+      [Conditional("DEBUG")]
+      public void Stop()
+      {
         // Get the current stopwatch in TLS -- see above comments (in
-
         // Start) for details on thread-safety.
 
         Stopwatch sw = GetWatch();
 
         // First, ensure we are running. If the stopwatch isn't running
-
         // yet, we ignore this call. This is consistent with the System.
-
         // Diagnostics.Stopwatch class's behavior.
 
         if (sw != null && sw.IsRunning)
-
         {
+          // Add the stopwatch's total time to our instance counter.
+          // This has to be an interlocked operation, because the whole
+          // point of this class is to be shared across threads. 'ticks'
+          // is the only instance state.
 
-            // Add the stopwatch's total time to our instance counter.
+          Interlocked.Add(ref ticks, sw.ElapsedTicks);
 
-            // This has to be an interlocked operation, because the whole
+          // We reset the stopwatch because we want to start at 0 upon
+          // the next invocation to 'Start' -- the cumulative time is
+          // kept in the 'ticks' variable.
+          sw.Reset();
 
-            // point of this class is to be shared across threads. 'ticks'
-
-            // is the only instance state.
-
-            Interlocked.Add(ref ticks, sw.ElapsedTicks);
-
-            // We reset the stopwatch because we want to start at 0 upon
-
-            // the next invocation to 'Start' -- the cumulative time is
-
-            // kept in the 'ticks' variable.
-
-            sw.Reset();
-
-            // We can now end the thread-affinity that was started in the
-
-            // Start operation above.
-
-            Thread.EndThreadAffinity();
-
+          // We can now end the thread-affinity that was started in the
+          // Start operation above.
+          Thread.EndThreadAffinity();
         }
+      }
 
-    }
-
-    class WeakRefEqualityComparer : IEqualityComparer<WeakReference>
-
-    {
-
+      class WeakRefEqualityComparer : IEqualityComparer<WeakReference>
+      {
         internal static WeakRefEqualityComparer Comparer =
-
             new WeakRefEqualityComparer();
 
         public bool Equals(WeakReference wr1, WeakReference wr2)
-
         {
+          // For purposes of our hash-table, if two weak-references
+          // refer to the same object, we consider them equal.
 
-            // For purposes of our hash-table, if two weak-references
+          object o1 = wr1.Target;
+          object o2 = wr2.Target;
 
-            // refer to the same object, we consider them equal.
+          if (!wr1.IsAlive || !wr2.IsAlive)
+            return false;
 
-            object o1 = wr1.Target;
+          // We shouldn't ever have null weak-references that aren't
+          // dead.
+          Debug.Assert(o1 != null && o2 != null);
 
-            object o2 = wr2.Target;
-
-            if (!wr1.IsAlive || !wr2.IsAlive)
-
-                return false;
-
-            // We shouldn't ever have null weak-references that aren't
-
-            // dead.
-
-            Debug.Assert(o1 != null && o2 != null);
-
-            // If the two underlying objects are equal, we pretend the
-
-            // weak-refs are too.
-
-            return o1.Equals(o2);
-
+          // If the two underlying objects are equal, we pretend the
+          // weak-refs are too.
+          return o1.Equals(o2);
         }
 
         public int GetHashCode(WeakReference wr)
-
         {
+          object o = wr.Target;
 
-            object o = wr.Target;
+          // Just return 0 for dead objects. We actually shouldn't
+          // ever use a dead object for hashing, although there could
+          // be some benign races above that result in this case. I
+          // haven't convinced myself otherwise, and they will get clean-
+          // ed up with the normal finalization code-path. It's A-OK.
 
-            // Just return 0 for dead objects. We actually shouldn't
+          if (!wr.IsAlive)
+            return 0;
 
-            // ever use a dead object for hashing, although there could
+          // Again, shouldn't get a live weak-ref that has a null
+          // object ref.
+          Debug.Assert(o != null);
 
-            // be some benign races above that result in this case. I
-
-            // haven't convinced myself otherwise, and they will get clean-
-
-            // ed up with the normal finalization code-path. It's A-OK.
-
-            if (!wr.IsAlive)
-
-                return 0;
-
-            // Again, shouldn't get a live weak-ref that has a null
-
-            // object ref.
-
-            Debug.Assert(o != null);
-
-            // Now, simply return the underlying object's hash-code.
-
-            return o.GetHashCode();
-
+          // Now, simply return the underlying object's hash-code.
+          return o.GetHashCode();
         }
-
+      }
     }
-
-}
 

--- a/_posts/2006-04-16-read-tearing-and-lock-freedom.md
+++ b/_posts/2006-04-16-read-tearing-and-lock-freedom.md
@@ -39,8 +39,8 @@ techniques... but otherwise, stay far, far away. (Have I made enough
 qualifications and disclaimers yet?))
 
 If you access individual pointer-sized byte segments of the data structure,
-such as 32-bit aligned segments (e.g. _volatile _or _\_\_declspec(align(_x_))
-_in VC++, all values on the CLR), you can load and store in a known order.
+such as 32-bit aligned segments (e.g. `volatile` or `__declspec(align(x))`
+in VC++, all values on the CLR), you can load and store in a known order.
 Furthermore, you need to use the appropriate types of loads and stores with
 fences in the appropriate places; load/acquire and store/release are usually
 adequate. You can then use the intrinsic properties of this order to make
@@ -51,7 +51,7 @@ For example, imagine you have some code that increments a 64-bit counter on a
 increment the low 32-bits, followed by the high, and if you always read the
 high, followed by the low, you'll be guaranteed that, should you read a torn
 value, it will be too low rather than too high (not counting for overflow, of
-course). Sometimes it can be _really _low, such as when the low 32-bits wrap
+course). Sometimes it can be _really_ low, such as when the low 32-bits wrap
 back to 0, in which case the higher 32-bit increment needs to carry one.
 Depending on your situation, this might be precisely what you are looking for.
 (I wrote some code last week that needed exactly this.)
@@ -59,97 +59,70 @@ Depending on your situation, this might be precisely what you are looking for.
 For example, your typical code might read and write under a lock, in
 VC++/Win32:
 
-> ULONGLONG ReadCounter\_Lock( volatile ULONGLONG \* pTarget, CRITICAL\_SECTION
-> \* pCs) { ULONGLONG val;
->
->
->
->     EnterCriticalSection(pCs); val = \*pTarget; LeaveCriticalSection(pCs);
->
->
->
->     return val; }
->
->
->
-> ULONGLONG IncrCounter\_Lock( volatile ULONGLONG \* pTarget, CRITICAL\_SECTION
-> \* pCs) { ULONGLONG val;
->
->
->
->     EnterCriticalSection(pCs); val = \*pTarget; \*pTarget = val + 1;
->     LeaveCriticalSection(pCs);
->
->
->
->     return val; }
+    ULONGLONG ReadCounter_Lock(volatile ULONGLONG * pTarget, CRITICAL_SECTION * pCs)
+    { 
+      ULONGLONG val;
+
+      EnterCriticalSection(pCs);
+      val = *pTarget;
+      LeaveCriticalSection(pCs);
+
+      return val;
+    }
+
+    ULONGLONG IncrCounter_Lock(volatile ULONGLONG * pTarget, CRITICAL_SECTION * pCs)
+    {
+      ULONGLONG val;
+
+      EnterCriticalSection(pCs);
+      val = *pTarget;
+      *pTarget = val + 1;
+      LeaveCriticalSection(pCs);
+
+      return val;
+    }
 
 But, using the load/store order described above, it can become lock free:
 
-> #define LO\_LONG(x) (reinterpret\_cast<volatile LONG \*>((x))) #define
-> HI\_LONG(x) (reinterpret\_cast<volatile LONG \*>((x)) + 1)
->
->
->
-> ULONGLONG ReadCounter\_NoLock(volatile ULONGLONG \* pTarget) { ULONGLONG val;
->
->
->
-> #ifdef \_Win64
->
->
->
->     val = \*pTarget;
->
->
->
-> #else
->
->
->
->     // Read high 32-bits first, then low: \*HI\_LONG(&val) =
->     \*HI\_LONG(pTarget); \*LO\_LONG(&val) = \*LO\_LONG(pTarget);
->
->
->
-> #endif
->
->
->
->     return val; }
->
->
->
-> ULONGLONG IncrCounter\_NoLock( volatile ULONGLONG \* pTarget) { ULONGLONG
-> oldVal;
->
->
->
-> #ifdef \_Win64
->
->
->
->     oldVal = static\_cast<LONGLONG>(
->     InterlockedIncrement64(static\_cast<LONGLONG \*>(pTarget)));
->
->
->
-> #else
->
->
->
->     // Increment the low 32-bits first, then high: if ((\*LO\_LONG(&oldVal) =
->     InterlockedIncrement(LO\_LONG(pTarget))) == 0) { \*HI\_LONG(&oldVal) =
->     InterlockedIncrement(HI\_LONG(pTarget)); } else { \*HI\_LONG(&oldVal) =
->     \*HI\_LONG(pTarget); }
->
->
->
-> #endif
->
->
->
->     return oldVal; }
+    #define LO_LONG(x) (reinterpret_cast<volatile LONG *>((x)))
+    #define HI_LONG(x) (reinterpret_cast<volatile LONG *>((x)) + 1)
+
+    ULONGLONG ReadCounter_NoLock(volatile ULONGLONG * pTarget)
+    {
+      ULONGLONG val;
+
+    #ifdef _Win64
+      val = *pTarget;
+    #else
+      // Read high 32-bits first, then low:
+      *HI_LONG(&val) = *HI_LONG(pTarget);
+      *LO_LONG(&val) = *LO_LONG(pTarget);
+    #endif
+
+      return val;
+    }
+
+    ULONGLONG IncrCounter_NoLock(volatile ULONGLONG * pTarget)
+    {
+      ULONGLONG oldVal;
+
+    #ifdef _Win64
+      oldVal = static_cast<LONGLONG>(
+        InterlockedIncrement64(static_cast<LONGLONG *>(pTarget)));
+    #else
+      // Increment the low 32-bits first, then high:
+      if ((*LO_LONG(&oldVal) = InterlockedIncrement(LO_LONG(pTarget))) == 0)
+      {
+        *HI_LONG(&oldVal) = InterlockedIncrement(HI_LONG(pTarget));
+      }
+      else
+      {
+        *HI_LONG(&oldVal) = *HI_LONG(pTarget);
+      }
+    #endif
+
+      return oldVal;
+    }
 
 It's obvious which is simpler to code, understand, and maintain. But the latter
 technique can come in handy when you're in a pinch.
@@ -162,7 +135,7 @@ excellent read. Most of it isn't built and ready for you to use today, but the
 details of the algorithms are in there if you'd like to play around a little.
 And there's a lot of literature out there about creating lock-free data
 structures. Interestingly, you can end up worse off than if you'd used a lock
-in the first place. Many such lock free algorithms are _optimistic _meaning
+in the first place. Many such lock free algorithms are _optimistic_ meaning
 that they do a bunch of work hoping not to run into contention; when they do,
 they have to throw away work, rinse, and repeat. Your mileage can vary
 dramatically based on workload.

--- a/_posts/2006-05-03-usermode-apcs-and-managed-code.md
+++ b/_posts/2006-05-03-usermode-apcs-and-managed-code.md
@@ -22,52 +22,47 @@ post](http://blogs.msdn.com/oldnewthing/archive/2006/05/03/589110.aspx) talks
 about queueing user-mode APCs in Win32.
 
 When you block in managed code, the CLR is responsible for figuring out the
-correct style of wait. This ends up in a CoWaitForMultipleHandles (on Win2k+)
-or MsgWaitForMultipleObjectsEx if you're executing in an STA; else, this ends
+correct style of wait. This ends up in a `CoWaitForMultipleHandles` (on Win2k+)
+or `MsgWaitForMultipleObjectsEx` if you're executing in an STA; else, this ends
 up in a non-pumping wait, such as
-WaitForSingleObjectEx/WaitForMultipleObjectsEx. In any case, the wait is
+`WaitForSingleObjectEx`/`WaitForMultipleObjectsEx`. In any case, the wait is
 alertable, meaning that user-mode APCs will have a chance to run. There are
 various blocking calls hidden in Win32 and the CLR itself, so it's not
 guaranteed that all waits are alertable; but any that originate from managed
 code are, which we hope is a significant percentage.
 
 This code illustrates a simple user-mode APC reentering as we do an alertable
-wait (via Thread.CurrentThread.Join(0)):
+wait (via `Thread.CurrentThread.Join(0)`):
 
-> using System; using System.Runtime.InteropServices; using System.Threading;
->
->
->
-> static class Program {
->
->     static void Main() { QueueUserAPC( delegate { Console.WriteLine("APC
->     fired"); }, GetCurrentThread(), UIntPtr.Zero);
->
->
->
->         Console.WriteLine("Doing join"); Thread.CurrentThread.Join(0);
->         Console.WriteLine("Finishing join"); }
->
->
->
->     delegate void APCProc(UIntPtr dwParam);
->
->
->
->     [DllImport("kernel32.dll")] static extern uint QueueUserAPC(APCProc
->     pfnAPC, IntPtr hThread, UIntPtr dwData);
->
->
->
->     [DllImport("kernel32.dll")] static extern IntPtr GetCurrentThread();
->
-> }
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Threading;
+
+    static class Program {
+      static void Main() {
+        QueueUserAPC(
+          delegate { Console.WriteLine("APC fired"); },
+          GetCurrentThread(), UIntPtr.Zero);
+
+        Console.WriteLine("Doing join");
+        Thread.CurrentThread.Join(0);
+        Console.WriteLine("Finishing join");
+      }
+
+      delegate void APCProc(UIntPtr dwParam);
+
+      [DllImport("kernel32.dll")]
+      static extern uint QueueUserAPC(APCProc pfnAPC, IntPtr hThread, UIntPtr dwData);
+
+      [DllImport("kernel32.dll")]
+      static extern IntPtr GetCurrentThread();
+    }
 
 While this technique seems like an effective way to reuse a thread while it is
 blocked -- for example, you might contemplate doing this for thread-pool
 threads -- a little problem called thread affinity tends to arise. [I wrote
 about this in terms of COM reentrancy
-before](http://www.bluebytesoftware.com/blog/PermaLink.aspx?guid=1ca19b0e-ef5b-4efc-b614-48d8c913efb9).
+before](http://joeduffyblog.com/2005/07/22/pump-me-baby-one-more-time-and-break-my-invariants/).
 An APC reentering doesn't perform a context transition, so even if we used a
 logical context to store such state, the problem would still exist. The simple
 fact is that user-mode APCs are good for system bookkeeping, but not for

--- a/_posts/2006-05-07-databases-and-concurrency.md
+++ b/_posts/2006-05-07-databases-and-concurrency.md
@@ -37,7 +37,7 @@ scalability due to dynamic fine-grained locking techniques and policies, while
 supplying conveniences such as intelligent contention management and deadlock 
 detection. And of course reliability is improved, because of the all-or-nothing 
 semantics of transactions. Even in the face of [asynchronous thread 
-aborts](http://www.bluebytesoftware.com/blog/PermaLink.aspx?guid=c1898a31-a0aa-40af-871c-7847d98f1641), 
+aborts](http://joeduffyblog.com/2005/09/29/rude-unloads-and-orphaned-locks/), 
 a transaction can ensure inconsistent state isn't left behind to corrupt a 
 process, greatly improving the reliability of software at a surprisingly low 
 cost. [Software transactional 

--- a/_posts/2006-05-07-to-parallelize-or-not-to-parallelize-that-is-the-question.md
+++ b/_posts/2006-05-07-to-parallelize-or-not-to-parallelize-that-is-the-question.md
@@ -47,27 +47,27 @@ the machine state, which can aid in this process, e.g.:
 
 - [System.Environment.ProcessorCount](http://msdn.microsoft.com/library/default.asp?url=/library/en-us/sysinfo/base/getsysteminfo.asp): 
   This property (new in 2.0) tells you how many hardware threads are on the 
-system. Note that the number includes hyper-threads on Intel architectures, 
-which really shouldn't be counted as a full parallel unit when deciding whether 
-to parallelize your code. 
-[GetSystemInfo](http://msdn.microsoft.com/library/default.asp?url=/library/en-us/sysinfo/base/getsysteminfo.asp) 
-can give you richer information, albeit with some P/Invoke nonsense. We should 
-give a better interface into this data for the next version of the Framework.
+  system. Note that the number includes hyper-threads on Intel architectures, 
+  which really shouldn't be counted as a full parallel unit when deciding whether 
+  to parallelize your code. 
+  [GetSystemInfo](http://msdn.microsoft.com/library/default.asp?url=/library/en-us/sysinfo/base/getsysteminfo.asp) 
+  can give you richer information, albeit with some P/Invoke nonsense. We should 
+  give a better interface into this data for the next version of the Framework.
 
 - Processor:% Processor Time performance counter: This gives you the % 
   utilization of a specific processor and allows asynchronous querying. Using 
-it, you could query each processor on the system to figure out what the overall 
-system utilization is, and specifically how many sub-parts to break your problem 
-into. The CLR thread-pool uses this today to decide when to inject or retire 
-threads. You can use it too to determine whether introducing parallelism is a 
-wise thing to do. Although your code may not have a lot of "context," this is 
-often a good heuristic that even leaf level algorithms can use.
+  it, you could query each processor on the system to figure out what the overall 
+  system utilization is, and specifically how many sub-parts to break your problem 
+  into. The CLR thread-pool uses this today to decide when to inject or retire 
+  threads. You can use it too to determine whether introducing parallelism is a 
+  wise thing to do. Although your code may not have a lot of "context," this is 
+  often a good heuristic that even leaf level algorithms can use.
 
 - System:Processor Queue Length performance counter: For more sophisticated 
   situations, you can not only key off of the processor utilization, but also 
-off the queue length of processes waiting to be scheduled. For a really deep 
-queue (say, more than 2x the number of processors), introducing additional work 
-is likely to lead to unnecessary waiting.
+  off the queue length of processes waiting to be scheduled. For a really deep 
+  queue (say, more than 2x the number of processors), introducing additional work 
+  is likely to lead to unnecessary waiting.
 
 Using these are apt to lead to statistically good decisions. But clearly this is 
 a heuristic, and as such the state of the system could change dramatically 

--- a/_posts/2006-05-24-verifiable-byref-returns.md
+++ b/_posts/2006-05-24-verifiable-byref-returns.md
@@ -17,18 +17,18 @@ author:
   first_name: ''
   last_name: ''
 ---
-In managed code, you can pass ByRefs "down the stack." You can't do much aside 
-from that, however, other than use things like ldind and stind on them. And of 
+In managed code, you can pass `ByRef`s "down the stack." You can't do much aside 
+from that, however, other than use things like `ldind` and `stind` on them. And of 
 course, you can cast them to native pointers, store them elsewhere, and so on, 
 but those sorts of (evil) things are unverifiable.
 
 Right? Well, sort of.
 
 In Whidbey, we made a change to the verification rules such that a function can 
-now return a ByRef to a caller. This of course is safe so long as the ByRef 
+now return a `ByRef` to a caller. This of course is safe so long as the `ByRef` 
 doesn't refer to a stack location. A field ref inside a heap-allocated object, 
 static field ref, or an array element ref are all just fine. And of course, a 
-function can just return a ByRef that was passed to it as an argument. Take a 
+function can just return a `ByRef` that was passed to it as an argument. Take a 
 look at this IL:
 
 ```
@@ -62,11 +62,11 @@ look at this IL:
 }
 ```
 
-Function f verifies just fine, since it just returns a ByRef to a static field, 
-whereas function g fails verification, because it returns a ByRef to a local on 
+Function `f` verifies just fine, since it just returns a `ByRef` to a static field, 
+whereas function `g` fails verification, because it returns a `ByRef` to a local on 
 the stack. You actually can't write code to produce the IL shown above from any 
-of Microsoft's compilers except for VC++, i.e. C# won't let you say "static ref 
-int f() { return ref s\_x; }".
+of Microsoft's compilers except for VC++, i.e. C# won't let you say
+`static ref int f() { return ref s_x; }`.
 
 Now, why would you ever want such a thing? VC++ needed it, for example, to 
 implement STL.NET. Traditional STL returns references to elements inside of 
@@ -78,6 +78,6 @@ Interestingly, this doesn't change the ECMA Specification. It's always been
 loose on the issue, saying in Section 12.1.1.2 of Partition I: "Verification 
 restrictions guarantee that, if all code is verifiable, a managed pointer to a 
 value on the evaluation stack doesn't outlast the life of the location to which 
-it points." Since you can't return a ByRef to a stack location, we don't violate 
+it points." Since you can't return a `ByRef` to a stack location, we don't violate 
 this guarantee. Our previous verifier was simply being overly strict.
 

--- a/_posts/2006-05-30-stack-allocations-and-fixed-arrays.md
+++ b/_posts/2006-05-30-stack-allocations-and-fixed-arrays.md
@@ -58,7 +58,7 @@ unsafe class Program {
 The use of this is of course almost always limited to unmanaged interop 
 scenarios. For example, there's at least one place in the BCL where we use this 
 to stack allocate the binary layout of a security descriptor that we then pass 
-into the Win32 CreateMutex API, which avoids having to create a new interop 
+into the Win32 `CreateMutex` API, which avoids having to create a new interop 
 struct. (Whether such hacks are a good thing to put in our code-base is another 
 topic altogether...)
 

--- a/_posts/2006-06-11-implementing-a-highperf-iasyncresult-addendum.md
+++ b/_posts/2006-06-11-implementing-a-highperf-iasyncresult-addendum.md
@@ -22,20 +22,20 @@ received a few mails on the ordering of the completion sequence. It was wrong
 and has been updated. Thanks to [those who pointed this 
 out](http://pluralsight.com/blogs/dbox/).
 
-I used the following incorrect ordering: 1) set IsCompleted to true, 2) invoke 
+I used the following incorrect ordering: 1) set `IsCompleted` to `true`, 2) invoke 
 the callback, and 3) signal the handle.
 
 This can lead to deadlocks if the callback waits on the handle. My 
-implementation carefully avoided EndXxx-induced deadlocks (by checking 
-IsCompleted before waiting on the handle), but if the callback directly 
-WaitOne's on the IAsyncResult.AsyncWaitHandle property, the callback will of 
+implementation carefully avoided `EndXxx`-induced deadlocks (by checking 
+`IsCompleted` before waiting on the handle), but if the callback directly 
+`WaitOne`'s on the `IAsyncResult.AsyncWaitHandle` property, the callback will of 
 course deadlock. Directly accessing the handle might be attractive to the 
-callback author, especially for higher level orchestration via WaitAny and 
-WaitAll. So it's probably something we'd like to support. One way to avoid this 
-is to invoke the callback asynchronously with BeginInvoke, but a better solution 
+callback author, especially for higher level orchestration via `WaitAny` and 
+`WaitAll`. So it's probably something we'd like to support. One way to avoid this 
+is to invoke the callback asynchronously with `BeginInvoke`, but a better solution 
 is to use the correct ordering instead.
 
-The correct ordering is: 1) set IsCompleted to true, 2) signal the handle, and 
+The correct ordering is: 1) set `IsCompleted` to `true`, 2) signal the handle, and 
 3) invoke the callback.
 
 The first version I wrote had the correct ordering, since that seemed to be the 
@@ -50,14 +50,14 @@ network IO APIs since V1.0 so I think it's just wrong.
 
 It's worth pointing out that the network classes already use a lazy allocation 
 scheme very similar to the one I wrote about. Check out the 
-System.Net.LazyAsyncResult internal type in System.dll. I'm advocating for 
+`System.Net.LazyAsyncResult` internal type in System.dll. I'm advocating for 
 moving file IO onto the same plan in the next release of the Framework. We'll 
 see how it turns out.
 
 Lastly, some might notice I originally said this would be a two part series. 
 Well, I wrote a whole bunch of code to implement a sophisticated LRU-based 
-resurrection caching scheme--to avoid allocating IAsyncResults every time--and 
-then realized that my example doesn't do anything expensive on IAsyncResult 
+resurrection caching scheme--to avoid allocating `IAsyncResults` every time--and 
+then realized that my example doesn't do anything expensive on `IAsyncResult` 
 creation that would warrant such a thing. The result? It was actually slower 
 than the ordinary lazy version I posted a couple weeks back. I think the 
 techniques I used are interesting nonetheless, so I am going to try and rework 

--- a/_posts/2006-06-17-tebs-and-stacks.md
+++ b/_posts/2006-06-17-tebs-and-stacks.md
@@ -26,11 +26,11 @@ PTEB NtCurrentTeb();
 This gives you access to the current thread's TEB (thread environment block), 
 which is a per-thread data structure that holds things like a pointer to the SEH 
 exception chain, stack range, TLS, fiber information, and so forth. This 
-function actually returns you a PTEB, which is defined as \_TEB\*. \_TEB is an 
+function actually returns you a PTEB, which is defined as `_TEB*`. `_TEB` is an 
 internal data structure defined in winternl.h, and consists of a bunch of byte 
-arrays. You can cast this to PNT\_TIB (defined as \_NT\_TIB\*), which gives you 
-access to the data in a strongly typed way. And \_NT\_TIB is a documented data 
-structure, unlike \_TEB, meaning you can actually rely on it not breaking 
+arrays. You can cast this to `PNT_TIB` (defined as `_NT_TIB*`), which gives you 
+access to the data in a strongly typed way. And `_NT_TIB` is a documented data 
+structure, unlike `_TEB`, meaning you can actually rely on it not breaking 
 between versions of Windows.
 
 For example, this code prints out the current thread's stack base and limit. The 
@@ -73,11 +73,11 @@ printf("Base = %p, Limit = %p\r\n",
     pStackBase, pStackLimit);
 ```
 
-Unfortunately, the \_asm keyword is not supported on all architectures, so the 
+Unfortunately, the `_asm` keyword is not supported on all architectures, so the 
 above code is only guaranteed to work on x86 (e.g. the VC++ Intel Itanium 
 compiler doesn't support it). Furthermore, the hardcoded offsets 04h and 08h are 
 clearly wrong on 64-bit: you need more than 4 bytes to represent a 64-bit 
-pointer. NtCurrentTeb hides all of this and uses whatever platform-specific 
+pointer. `NtCurrentTeb` hides all of this and uses whatever platform-specific 
 technique is needed to retrieve the information.
 
 Matt Pietrek's [1996](http://www.microsoft.com/msj/archive/S2CE.aspx) and 


### PR DESCRIPTION
The delay after the previous PR took longer than I expected. But anyway it seems that with this commit all major WordPress-to-Markdown conversion problems are fixed. Hooray! Every following post looks ok, and I could only fix some broken urls and add more backticks around identifiers mentioned in the text :)